### PR TITLE
Allow client to provide interceptors to requests

### DIFF
--- a/src/base_client.ts
+++ b/src/base_client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 
 import { ClientConfig } from './core/ClientConfig'
 
@@ -6,12 +6,28 @@ export class LuneClient {
     protected client: AxiosInstance
     protected config: ClientConfig
 
-    constructor(apiKey: string, baseUrl: string = 'https://api.lune.co', apiVersion: string = '1') {
+    constructor(
+        apiKey: string,
+        baseUrl: string = 'https://api.lune.co',
+        apiVersion: string = '1',
+        requestInterceptors: ((
+            req: AxiosRequestConfig,
+        ) => AxiosRequestConfig | Promise<AxiosRequestConfig>)[] = [],
+        responseInterceptors: ((
+            req: AxiosRequestConfig,
+        ) => AxiosRequestConfig | Promise<AxiosRequestConfig>)[] = [],
+    ) {
         this.config = {
             BASE_URL: `${baseUrl}/v{api-version}`,
             VERSION: apiVersion,
             BEARER_TOKEN: apiKey,
         }
         this.client = axios.create()
+        for (const requestInterceptor of requestInterceptors) {
+            this.client.interceptors.request.use(requestInterceptor)
+        }
+        for (const responseInterceptor of responseInterceptors) {
+            this.client.interceptors.response.use(responseInterceptor)
+        }
     }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 
 import { ClientConfig } from './core/ClientConfig'
 import { AccountsService } from './services/AccountsService.js'
@@ -27,13 +27,29 @@ export class LuneClient {
     protected client: AxiosInstance
     protected config: ClientConfig
 
-    constructor(apiKey: string, baseUrl: string = 'https://api.lune.co', apiVersion: string = '1') {
+    constructor(
+        apiKey: string,
+        baseUrl: string = 'https://api.lune.co',
+        apiVersion: string = '1',
+        requestInterceptors: ((
+            req: AxiosRequestConfig,
+        ) => AxiosRequestConfig | Promise<AxiosRequestConfig>)[] = [],
+        responseInterceptors: ((
+            req: AxiosRequestConfig,
+        ) => AxiosRequestConfig | Promise<AxiosRequestConfig>)[] = [],
+    ) {
         this.config = {
             BASE_URL: `${baseUrl}/v{api-version}`,
             VERSION: apiVersion,
             BEARER_TOKEN: apiKey,
         }
         this.client = axios.create()
+        for (const requestInterceptor of requestInterceptors) {
+            this.client.interceptors.request.use(requestInterceptor)
+        }
+        for (const responseInterceptor of responseInterceptors) {
+            this.client.interceptors.response.use(responseInterceptor)
+        }
     }
 }
 applyMixins(LuneClient, [


### PR DESCRIPTION
To make it easier to handle the requests on the client side, allow for
interceptors to be added that can either change the request or the
response in a predetermined way. These are given at client creation time
and are optional.

This is a basic use case, we have in our current dashboard to do
camelCase -> snake_case conversion and viceversa. I'm not sure this is
needed on the dashboard in the future, but the functionality itself is
still valuable.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>