### PR TITLE
Add automated commands for version management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,5 +99,20 @@ build-from-source: install check-linting build
 # Rebuild final client and build from source. This rebuilds based on base_client
 rebuild-from-source: install build-final-client fix-linting build
 
+patch-version:
+	npm --no-git-tag-version version patch
+	cd src && npm --no-git-tag-version version patch
+	npm ci
+
+minor-version:
+	npm --no-git-tag-version version minor
+	cd src && npm --no-git-tag-version version minor
+	npm ci
+
+major-version:
+	npm --no-git-tag-version version major
+	cd src && npm --no-git-tag-version version major
+	npm ci
+
 publish:
 	cd dist && npm publish --access public


### PR DESCRIPTION
Allow to up the version in a patch/minor/major fashion. Both
package.json files are update and even the package-lock.json by
performing a clean install.
README changes will come later since working on a bit of revamp.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>