### PR TITLE
Add homepage pointing to lune docs

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
   ],
   "author": "Lune Climate",
   "license": "MIT",
+  "homepage": "https://docs.lune.co/",
   "repository": {
     "type": "git",
     "url": "https://github.com/lune-climate/lune-ts"


### PR DESCRIPTION
Homepage on the npm package is better to be pointed at our docs.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>