### PR TITLE
Fix indentation on distributed package.json

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -6,10 +6,10 @@
   "module": "esm/client.js",
   "types": "esm/client.d.ts",
   "exports": {
-      ".": {
-          "import": "./esm/client.js",
-          "require": "./cjs/client.js"
-      }
+    ".": {
+        "import": "./esm/client.js",
+        "require": "./cjs/client.js"
+    }
   },
   "keywords": [
     "Lune"


### PR DESCRIPTION
The whole file uses 2 space for indentation, so make it consistent
throughout.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>