### PR TITLE
Convert models/schema parameters to camelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ the schema is made.
 
 ## Base client changes
 
+The generated models and schemas are modified to have their parameters as camelCase instead
+of snake_case. The TS/JS ecosystem prefers camelCase while http arguments usually do snake_case
+so we convert them to better reflect usage in code.
+
 The original services are generated as classes, where each method is a static method.
 As an example, to place an order, one would call it as: `OrdersService.createOrderByQuantity`
 A service in the case of openapi schema is a `tagGroup`, while the method is the `operationId`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",
+        "camelcase-keys": "^7.0.2",
+        "snakecase-keys": "^5.1.2",
         "ts-results-es": "^3.4.0"
       },
       "devDependencies": {
@@ -648,7 +650,34 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
         "node": ">=10"
       },
@@ -777,6 +806,20 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2026,6 +2069,19 @@
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2036,6 +2092,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -2095,6 +2162,20 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/object-inspect": {
       "version": "1.12.0",
@@ -2351,6 +2432,17 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -2520,6 +2612,44 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snake-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/snakecase-keys": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.1.2.tgz",
+      "integrity": "sha512-fvtDQZqPBqYb0dEY97TGuOMbN2NJ05Tj4MaoKwjTKkmjcG6mrd58JYGr23UWZRi6Aqv49Fk4HtjTIStOQenaug==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/snakecase-keys/node_modules/type-fest": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+      "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {
@@ -3311,8 +3441,25 @@
     "camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+    },
+    "camelcase-keys": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+      "requires": {
+        "camelcase": "^6.3.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -3402,6 +3549,22 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "emoji-regex": {
@@ -4311,6 +4474,21 @@
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4319,6 +4497,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
     "merge2": {
       "version": "1.4.1",
@@ -4368,6 +4551,22 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "object-inspect": {
       "version": "1.12.0",
@@ -4538,6 +4737,11 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -4641,6 +4845,39 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "snakecase-keys": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.1.2.tgz",
+      "integrity": "sha512-fvtDQZqPBqYb0dEY97TGuOMbN2NJ05Tj4MaoKwjTKkmjcG6mrd58JYGr23UWZRi6Aqv49Fk4HtjTIStOQenaug==",
+      "requires": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+          "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ=="
+        }
       }
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.21.1",
+    "camelcase-keys": "^7.0.2",
+    "snakecase-keys": "^5.1.2",
     "ts-results-es": "^3.4.0"
   },
   "devDependencies": {

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -1,4 +1,6 @@
 import { AxiosError, AxiosInstance } from 'axios'
+import camelCaseKeys from 'camelcase-keys'
+import snakeCaseKeys from 'snakecase-keys'
 import { Err, Ok, Result } from 'ts-results-es'
 
 import { ApiError } from './ApiError.js'
@@ -167,11 +169,11 @@ const getHeaders = (config: ClientConfig, options: ApiRequestOptions): Headers =
 const getRequestBody = (options: ApiRequestOptions): any => {
     if (options.body) {
         if (options.mediaType?.includes('/json')) {
-            return JSON.stringify(options.body)
+            return JSON.stringify(snakeCaseKeys(options.body, { deep: true }))
         } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
             return options.body
         } else {
-            return JSON.stringify(options.body)
+            return JSON.stringify(snakeCaseKeys(options.body, { deep: true }))
         }
     }
 }
@@ -194,7 +196,7 @@ export const request = async <T>(
         data: body,
     })
         .then((response) => {
-            return Ok(response.data as T)
+            return Ok(camelCaseKeys(response.data, { deep: true }) as T)
         })
         .catch((error: AxiosError) => {
             return Err(new ApiError(error, options))

--- a/src/models/Account.ts
+++ b/src/models/Account.ts
@@ -14,7 +14,7 @@ export type Account = {
     /**
      * The unique identifier of the organisation this account belongs to
      */
-    organisation_id: string
+    organisationId: string
     /**
      * The Account's currency
      */
@@ -34,7 +34,7 @@ export type Account = {
      * Unit: Account currency
      *
      */
-    balance_outstanding: string
+    balanceOutstanding: string
     /**
      * The account's type.
      *

--- a/src/models/Activity.ts
+++ b/src/models/Activity.ts
@@ -50,28 +50,28 @@ export type Activity = {
     /**
      * Account's cash balance delta.
      *
-     * The previous balance plus `balance_delta` equals the current balance.
+     * The previous balance plus `balanceDelta` equals the current balance.
      *
      * Unit: Account currency
      *
      */
-    balance_delta: string
+    balanceDelta: string
     /**
      * The Account's outstanding balance at the time of this activity
      *
      * Unit: Account currency
      *
      */
-    balance_outstanding: string
+    balanceOutstanding: string
     /**
      * Account's outstanding balance delta.
      *
-     * The previous outstanding balance plus `balance_outstanding_delta` equals the current outstanding balance.
+     * The previous outstanding balance plus `balanceOutstandingDelta` equals the current outstanding balance.
      *
      * Unit: Account currency
      *
      */
-    balance_outstanding_delta: string
+    balanceOutstandingDelta: string
     /**
      * Quantity of CO2 offsets linked to this activity (tonnes CO2)
      */
@@ -79,17 +79,17 @@ export type Activity = {
     /**
      * The order's unique identifier
      */
-    order_id?: string
+    orderId: string
     /**
      * The project's unique identifier
      */
-    project_id?: string
+    projectId: string
     /**
      * The project's name
      */
-    project_name?: string
+    projectName: string
     /**
      * Activity creation timestamp
      */
-    created_at: string
+    createdAt: string
 }

--- a/src/models/Address.ts
+++ b/src/models/Address.ts
@@ -6,11 +6,11 @@ export type Address = {
     /**
      * A street and house number (or equivalent).
      */
-    street_line1: string
+    streetLine1: string
     /**
      * An address component more precise than a street and house number.
      */
-    street_line2?: string
+    streetLine2: string
     /**
      * The postal code in the format specific to the country it's in
      */
@@ -19,5 +19,5 @@ export type Address = {
     /**
      * A three-letter country code.
      */
-    country_code: string
+    countryCode: string
 }

--- a/src/models/Analytics.ts
+++ b/src/models/Analytics.ts
@@ -9,33 +9,33 @@ export type Analytics = {
     /**
      * The total monetary value of all completed orders for a given interval.
      */
-    total_completed_offset_value: string
+    totalCompletedOffsetValue: string
     /**
      * The total quantity in tCO2 of all completed orders for a given interval.
      */
-    total_completed_offset_quantity: string
+    totalCompletedOffsetQuantity: string
     /**
      * The total monetary value of all placed orders for a given interval.
      */
-    total_placed_offset_value: string
+    totalPlacedOffsetValue: string
     /**
      * The total quantity in tCO2 of all placed orders for a given interval.
      */
-    total_placed_offset_quantity: string
+    totalPlacedOffsetQuantity: string
     /**
      * An array of offest values grouped by completion date.
      */
-    completed_offset_values: Array<OffsetValueSeriesItem>
+    completedOffsetValues: Array<OffsetValueSeriesItem>
     /**
      * An array of offest quantities grouped by completion date.
      */
-    completed_offset_quantities: Array<OffsetQuantitySeriesItem>
+    completedOffsetQuantities: Array<OffsetQuantitySeriesItem>
     /**
      * An array of offest values grouped by placed date.
      */
-    placed_offset_values: Array<OffsetValueSeriesItem>
+    placedOffsetValues: Array<OffsetValueSeriesItem>
     /**
      * An array of offest quantities grouped by placed date.
      */
-    placed_offset_quantities: Array<OffsetQuantitySeriesItem>
+    placedOffsetQuantities: Array<OffsetQuantitySeriesItem>
 }

--- a/src/models/BundlePercentage.ts
+++ b/src/models/BundlePercentage.ts
@@ -9,7 +9,7 @@ export type BundlePercentage = {
     /**
      * The bundle's unique identifier
      */
-    bundle_id: string
+    bundleId: string
     /**
      * Selection percentage
      */

--- a/src/models/BundlePercentageRequest.ts
+++ b/src/models/BundlePercentageRequest.ts
@@ -9,7 +9,7 @@ export type BundlePercentageRequest = {
     /**
      * The bundle's unique identifier
      */
-    bundle_id: string
+    bundleId: string
     /**
      * Selection percentage
      */

--- a/src/models/BundleSummary.ts
+++ b/src/models/BundleSummary.ts
@@ -15,12 +15,12 @@ export type BundleSummary = {
      * Bundle unit price per tonne CO2
      *
      */
-    unit_price: string
+    unitPrice: string
     /**
      * Bundle unit price per tonne CO2 inclusive of fees
      *
      */
-    gross_unit_price: string
+    grossUnitPrice: string
     /**
      * Currency code
      */
@@ -28,11 +28,11 @@ export type BundleSummary = {
     /**
      * A bundle's image URL
      */
-    primary_image?: string
+    primaryImage: string
     /**
      * A bundle's high resolution image URL
      */
-    primary_image_hires?: string
+    primaryImageHires: string
     /**
      * The bundle's description
      */
@@ -45,13 +45,13 @@ export type BundleSummary = {
     /**
      * Quantity of CO2 offsets available to purchase (in tonnes).
      *
-     * If available_quantity is not set, assume there is an unlimited amount of offsets to purchase.
+     * If availableQuantity is not set, assume there is an unlimited amount of offsets to purchase.
      *
      */
-    available_quantity?: string
+    availableQuantity: string
     /**
      * Offset type classification
      *
      */
-    offset_type?: 'emissions_reduction' | 'carbon_removal'
+    offsetType: 'emissions_reduction' | 'carbon_removal'
 }

--- a/src/models/CompanyEmissionEstimate.ts
+++ b/src/models/CompanyEmissionEstimate.ts
@@ -22,7 +22,7 @@ export type CompanyEmissionEstimate = EmissionEstimate & {
         /**
          * Emissions associated with buying equipment and generating waste.
          */
-        material_and_waste: Mass
+        materialAndWaste: Mass
         /**
          * Emissions associated with purchasing energy (electricy, heating etc.)
          */
@@ -30,11 +30,11 @@ export type CompanyEmissionEstimate = EmissionEstimate & {
         /**
          * Emissions associated with business travels and commuting to/from work.
          */
-        travel_and_commute: Mass
+        travelAndCommute: Mass
         /**
          * Emissions associated with food and drinks.
          */
-        food_and_drink: Mass
+        foodAndDrink: Mass
         /**
          * Emissions associated with operating computer systems.
          */

--- a/src/models/CompanyEstimateRequest.ts
+++ b/src/models/CompanyEstimateRequest.ts
@@ -23,15 +23,15 @@ export type CompanyEstimateRequest = {
     /**
      * Share of employees working remotely (in percent)
      */
-    remote_employees_percentage: IntegerPercentage
+    remoteEmployeesPercentage: IntegerPercentage
     /**
      * Office area in square meters
      */
-    office_area: Area
+    officeArea: Area
     /**
      * The three-letter country code of the country where the company is located.
      */
-    country_code: string
+    countryCode: string
     /**
      * The company's postal code
      */
@@ -40,55 +40,55 @@ export type CompanyEstimateRequest = {
     /**
      * Electricity consumption in kWh
      */
-    electricity_consumption: number
+    electricityConsumption: number
     /**
      * Is the electricity provided by renewable source(s)?
      */
-    green_electricity_used: boolean
+    greenElectricityUsed: boolean
     /**
      * Yearly natural gas consumption in cubic meters
      */
-    gas_consumption: number
+    gasConsumption: number
     /**
      * Company cars
      */
-    company_cars: number
+    companyCars: number
     /**
      * Average yearly distance travelled per car
      */
-    average_car_distance_travelled: Distance
+    averageCarDistanceTravelled: Distance
     /**
      * Number of employees commuting by public transport
      */
-    employees_using_public_transport: number
+    employeesUsingPublicTransport: number
     /**
      * Number of short (under 3 hours) flights per year
      */
-    short_flights: number
+    shortFlights: number
     /**
      * Number of medium (between 3 and 6 hours) flights per year
      */
-    medium_flights: number
+    mediumFlights: number
     /**
      * Number of long (over 6 hours) flights per year
      */
-    long_flights: number
+    longFlights: number
     /**
      * Share of business or first class flights, in percent
      */
-    first_or_business_class_percentage: IntegerPercentage
+    firstOrBusinessClassPercentage: IntegerPercentage
     /**
      * Amount spend on food and drinks
      */
-    food_and_drinks_expenses: MonetaryAmount
+    foodAndDrinksExpenses: MonetaryAmount
     /**
      * Share of vegetarians or vegans in the company, in percent
      */
-    vegetarian_and_vegan_percentage: IntegerPercentage
+    vegetarianAndVeganPercentage: IntegerPercentage
     /**
      * New electronic devices (laptops, monitors, etc.) expenses
      */
-    electronic_device_expenses: MonetaryAmount
+    electronicDeviceExpenses: MonetaryAmount
     /**
      * The amount of garbage produced, in kilograms
      */
@@ -96,9 +96,9 @@ export type CompanyEstimateRequest = {
     /**
      * Share of recycled garbage, in percent
      */
-    recycled_garbage_percentage: IntegerPercentage
+    recycledGarbagePercentage: IntegerPercentage
     tech?: {
-        on_premise?: CompanyOnPremiseUse
+        onPremise: CompanyOnPremiseUse
         cloud?: CompanyCloudUse
     }
 }

--- a/src/models/CompanyOnPremiseUse.ts
+++ b/src/models/CompanyOnPremiseUse.ts
@@ -8,5 +8,5 @@ import type { MonetaryAmount } from './MonetaryAmount'
  * Company's own tech infrastructure details
  */
 export type CompanyOnPremiseUse = {
-    electricity_cost: MonetaryAmount
+    electricityCost: MonetaryAmount
 }

--- a/src/models/ContainerShippingMethod.ts
+++ b/src/models/ContainerShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 export type ContainerShippingMethod = {
-    vessel_type: 'container_ship'
+    vesselType: 'container_ship'
     /**
      * A container transport is either refrigerated or "dry" (not refrigerated). Dry transports
      * result in lower emissions.
@@ -25,7 +25,7 @@ export type ContainerShippingMethod = {
      * Asia to Africa and Africa to Asia.
      *
      */
-    trade_lane?:
+    tradeLane:
         | 'aggregated_panama_trade'
         | 'aggregated_transatlantic'
         | 'aggregated_transsuez'

--- a/src/models/CreateOrderByQuantityRequest.ts
+++ b/src/models/CreateOrderByQuantityRequest.ts
@@ -17,12 +17,12 @@ export type CreateOrderByQuantityRequest = {
     /**
      * Optional unique identifier provided by the client.
      *
-     * `idempotency_key` has two purposes:
+     * `idempotencyKey` has two purposes:
      * 1. Clients can safely retry order requests without accidentally performing the same operation twice. The current state of the original order is returned.
-     * 2. Clients can use `idempotency_key` to reconcile orders with other entities on their system.
+     * 2. Clients can use `idempotencyKey` to reconcile orders with other entities on their system.
      *
      */
-    idempotency_key?: string
-    bundle_selection?: BundleSelectionRequest
+    idempotencyKey: string
+    bundleSelection: BundleSelectionRequest
     metadata?: Metadata
 }

--- a/src/models/CreateOrderByValueRequest.ts
+++ b/src/models/CreateOrderByValueRequest.ts
@@ -16,12 +16,12 @@ export type CreateOrderByValueRequest = {
     /**
      * Optional unique identifier provided by the client.
      *
-     * `idempotency_key` has two purposes:
+     * `idempotencyKey` has two purposes:
      * 1. Clients can safely retry order requests without accidentally performing the same operation twice. The current state of the original order is returned.
-     * 2. Clients can use `idempotency_key` to reconcile orders with other entities on their system.
+     * 2. Clients can use `idempotencyKey` to reconcile orders with other entities on their system.
      *
      */
-    idempotency_key?: string
-    bundle_selection?: BundleSelectionRequest
+    idempotencyKey: string
+    bundleSelection: BundleSelectionRequest
     metadata?: Metadata
 }

--- a/src/models/ElectricityEstimateRequest.ts
+++ b/src/models/ElectricityEstimateRequest.ts
@@ -16,5 +16,5 @@ export type ElectricityEstimateRequest = {
      * the global average will be used.
      *
      */
-    country_code?: string
+    countryCode: string
 }

--- a/src/models/Error.ts
+++ b/src/models/Error.ts
@@ -9,7 +9,7 @@ export type Error = {
     /**
      * Immutable string representing a specific error.
      */
-    error_code:
+    errorCode:
         | 'account_suspended'
         | 'invalid_selected_account_id'
         | 'bundle_selection_not_100_pct'

--- a/src/models/FlightEstimateRequest.ts
+++ b/src/models/FlightEstimateRequest.ts
@@ -14,7 +14,7 @@ export type FlightEstimateRequest = {
      * Either the flying distance or the start/destination airport code (ICAO or IATA).
      */
     route: Distance | AirportSourceDestination
-    cabin_class?: CabinClass
+    cabinClass: CabinClass
     /**
      * Number of passengers the calculation should be applied to.
      * This parameter defaults to 1.

--- a/src/models/HugeOilTankerSeaShippingMethod.ts
+++ b/src/models/HugeOilTankerSeaShippingMethod.ts
@@ -3,6 +3,6 @@
 /* eslint-disable */
 
 export type HugeOilTankerSeaShippingMethod = {
-    vessel_type: 'sea_oil_tanker_huge'
+    vesselType: 'sea_oil_tanker_huge'
     fuel?: 'HFO' | 'MGO' | 'LNG'
 }

--- a/src/models/IdentifiedVesselShippingMethod.ts
+++ b/src/models/IdentifiedVesselShippingMethod.ts
@@ -7,5 +7,5 @@ export type IdentifiedVesselShippingMethod = {
      * The ship's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
      *
      */
-    vessel_imo_number: string
+    vesselImoNumber: string
 }

--- a/src/models/Merchant.ts
+++ b/src/models/Merchant.ts
@@ -10,7 +10,7 @@ export type Merchant = {
      * See https://github.com/greggles/mcc-codes for available codes.
      *
      */
-    category_code: string
+    categoryCode: string
     /**
      * The name of the merchant.
      */
@@ -18,5 +18,5 @@ export type Merchant = {
     /**
      * The three-letter code of the merchant's country.
      */
-    country_code: string
+    countryCode: string
 }

--- a/src/models/OffsetLink.ts
+++ b/src/models/OffsetLink.ts
@@ -45,7 +45,7 @@ export type OffsetLink = {
      * Whether to include the Offset link logo (defined in Account settings) in the footer.
      *
      */
-    use_logo: boolean
+    useLogo: boolean
     /**
      * The actual offset link URL that can be used to place orders
      */
@@ -60,12 +60,12 @@ export type OffsetLink = {
      * Bundle objects
      */
     bundles?: Array<Bundle>
-    created_at: Timestamp
+    createdAt: Timestamp
     status: OffsetLinkStatus
-    expires_at?: Timestamp
+    expiresAt: Timestamp
     /**
      * If true, the user of the Offset Link is required to pay by credit/debit card.
      *
      */
-    require_payment: boolean
+    requirePayment: boolean
 }

--- a/src/models/OffsetLinkAnalytics.ts
+++ b/src/models/OffsetLinkAnalytics.ts
@@ -12,10 +12,10 @@ export type OffsetLinkAnalytics = {
     /**
      * The number of unique visitors for the specific offset link
      */
-    unique_visitors: number
+    uniqueVisitors: number
     /**
      * The number of placed orders for the specific offset link
      */
-    placed_orders: number
+    placedOrders: number
     orders: Array<OffsetLinkOrder>
 }

--- a/src/models/OffsetLinkOrder.ts
+++ b/src/models/OffsetLinkOrder.ts
@@ -8,8 +8,8 @@ export type OffsetLinkOrder = {
     /**
      * The order's unique identifier
      */
-    order_id: string
-    created_at: Timestamp
+    orderId: string
+    createdAt: Timestamp
     /**
      * The email address of the user that placed an order through the offset link
      */
@@ -18,10 +18,10 @@ export type OffsetLinkOrder = {
         /**
          * The bundle's unique identifier
          */
-        bundle_id: string
+        bundleId: string
         /**
          * The bundle's name
          */
-        bundle_name: string
+        bundleName: string
     }>
 }

--- a/src/models/OffsetLinkRequest.ts
+++ b/src/models/OffsetLinkRequest.ts
@@ -36,16 +36,16 @@ export type OffsetLinkRequest = {
      * The email addresses of users that are allowed to use the offset link.
      */
     emails?: Array<string>
-    expires_at?: Timestamp
+    expiresAt: Timestamp
     /**
      * Whether to include the Offset link logo (defined in Account settings) in the footer.
      *
      */
-    use_logo: boolean
+    useLogo: boolean
     /**
      * If true, the user of the Offset Link is required to pay by credit/debit card.
      * This value cannot be updated once the offset link has been created.
      *
      */
-    require_payment?: boolean
+    requirePayment: boolean
 }

--- a/src/models/OffsetLinkUpdateRequest.ts
+++ b/src/models/OffsetLinkUpdateRequest.ts
@@ -36,10 +36,10 @@ export type OffsetLinkUpdateRequest = {
      * The email addresses of users that are allowed to use the offset link.
      */
     emails?: Array<string>
-    expires_at?: Timestamp
+    expiresAt: Timestamp
     /**
      * Whether to include the Offset link logo (defined in Account settings) in the footer.
      *
      */
-    use_logo: boolean
+    useLogo: boolean
 }

--- a/src/models/OrderBase.ts
+++ b/src/models/OrderBase.ts
@@ -17,12 +17,12 @@ export type OrderBase = {
     /**
      * Optional unique identifier provided by the client.
      *
-     * `idempotency_key` has two purposes:
+     * `idempotencyKey` has two purposes:
      * 1. Clients can safely retry order requests without accidentally performing the same operation twice. The current state of the original order is returned.
-     * 2. Clients can use `idempotency_key` to reconcile orders with other entities on their system.
+     * 2. Clients can use `idempotencyKey` to reconcile orders with other entities on their system.
      *
      */
-    idempotency_key?: string
+    idempotencyKey: string
     /**
      * Identifies whether the order has been placed by quantity (kg CO2) or value (monetary amount)
      */
@@ -45,14 +45,14 @@ export type OrderBase = {
      * Unit: order currency
      *
      */
-    offset_cost?: string
+    offsetCost: string
     /**
      * The total cost for the order inclusive of fees.
      *
      * Unit: order currency
      *
      */
-    total_cost?: string
+    totalCost: string
     /**
      * Represents Lune's fee.
      *
@@ -71,7 +71,7 @@ export type OrderBase = {
     /**
      * Order creation timestamp
      */
-    created_at: string
+    createdAt: string
     /**
      * bundles are set when the order's status is `placed`, `paid`, `allocated` or `complete`.
      *
@@ -101,7 +101,7 @@ export type OrderBase = {
     /**
      * The offset link identifier, if the order was placed through an offset link
      */
-    offset_link_id?: string
+    offsetLinkId: string
     /**
      * End-user email.
      *

--- a/src/models/OrderBundle.ts
+++ b/src/models/OrderBundle.ts
@@ -6,11 +6,11 @@ export type OrderBundle = {
     /**
      * The bundle's unique identifier
      */
-    bundle_id: string
+    bundleId: string
     /**
      * The bundle's name
      */
-    bundle_name: string
+    bundleName: string
     /**
      * Quantity for the specific bundle (tonnes CO2)
      */
@@ -21,24 +21,24 @@ export type OrderBundle = {
      * Unit: order currency
      *
      */
-    unit_price: string
+    unitPrice: string
     /**
      * Bundle unit price per tonne CO2 inclusive of fees.
      *
      * Unit: order currency
      *
      */
-    gross_unit_price: string
+    grossUnitPrice: string
     /**
      * Represents the net cost of offsets purchased by the order for this bundle.
      *
      * Unit: order currency
      *
      */
-    offset_cost: string
+    offsetCost: string
     /**
      * If true, there is no inventory necessary to fully satisfy the order for this bundle.
      *
      */
-    insufficient_available_quantity?: boolean
+    insufficientAvailableQuantity: boolean
 }

--- a/src/models/OrderByQuantity.ts
+++ b/src/models/OrderByQuantity.ts
@@ -8,5 +8,5 @@ export type OrderByQuantity = OrderBase & {
     /**
      * Represents the requested quantity of CO2 offsets to purchase in tonnes.
      */
-    requested_quantity: string
+    requestedQuantity: string
 }

--- a/src/models/OrderByValue.ts
+++ b/src/models/OrderByValue.ts
@@ -11,5 +11,5 @@ export type OrderByValue = OrderBase & {
      * Unit: order currency
      *
      */
-    requested_value: string
+    requestedValue: string
 }

--- a/src/models/OrderProject.ts
+++ b/src/models/OrderProject.ts
@@ -6,19 +6,19 @@ export type OrderProject = {
     /**
      * The project's unique identifier
      */
-    project_id: string
+    projectId: string
     /**
      * The project's name
      */
-    project_name: string
+    projectName: string
     /**
      * The project's offset type, eg Forest conservation, Afforestation, Direct Air Capture
      */
-    project_type: string
+    projectType: string
     /**
      * The project's unique slug
      */
-    project_slug: string
+    projectSlug: string
     /**
      * Carbon offset purchased (tonnes CO2)
      */
@@ -29,12 +29,12 @@ export type OrderProject = {
      * Unit: order currency
      *
      */
-    unit_price: string
+    unitPrice: string
     /**
      * Represents the net cost of offsets purchased by the order for this project.
      *
      * Unit: order currency
      *
      */
-    offset_cost: string
+    offsetCost: string
 }

--- a/src/models/OrderQuoteBase.ts
+++ b/src/models/OrderQuoteBase.ts
@@ -15,25 +15,25 @@ export type OrderQuoteBase = {
      * May be lower than `requested_quantity`.
      *
      */
-    estimated_quantity: string
+    estimatedQuantity: string
     /**
      * Estimated offset cost
      *
      * Unit: order quote currency
      *
      */
-    estimated_offset_cost: string
+    estimatedOffsetCost: string
     /**
      * Estimated total cost inclusive of Lune fees.
      *
      * Unit: order quote currency
      *
      */
-    estimated_total_cost: string
+    estimatedTotalCost: string
     /**
      * Estimated commission
      */
-    estimated_commission: string
+    estimatedCommission: string
     /**
      * Bundles included in the quote including quantity and cost breakdown.
      *

--- a/src/models/OrderQuoteByQuantity.ts
+++ b/src/models/OrderQuoteByQuantity.ts
@@ -8,5 +8,5 @@ export type OrderQuoteByQuantity = OrderQuoteBase & {
     /**
      * Requested quantity for the specific bundle (tonnes CO2)
      */
-    requested_quantity: string
+    requestedQuantity: string
 }

--- a/src/models/OrderQuoteByQuantityRequest.ts
+++ b/src/models/OrderQuoteByQuantityRequest.ts
@@ -13,5 +13,5 @@ export type OrderQuoteByQuantityRequest = {
      * Mass of CO2 offsets to purchase
      */
     mass: Mass
-    bundle_selection?: BundleSelectionRequest
+    bundleSelection: BundleSelectionRequest
 }

--- a/src/models/OrderQuoteByValue.ts
+++ b/src/models/OrderQuoteByValue.ts
@@ -8,5 +8,5 @@ export type OrderQuoteByValue = OrderQuoteBase & {
     /**
      * Requested order value inclusive of commission
      */
-    requested_value: string
+    requestedValue: string
 }

--- a/src/models/OrderQuoteByValueRequest.ts
+++ b/src/models/OrderQuoteByValueRequest.ts
@@ -12,5 +12,5 @@ export type OrderQuoteByValueRequest = {
      * Maximum price of CO2 offsets to purchase (in the account's currency)
      */
     value: string
-    bundle_selection?: BundleSelectionRequest
+    bundleSelection: BundleSelectionRequest
 }

--- a/src/models/PaginatedBase.ts
+++ b/src/models/PaginatedBase.ts
@@ -6,5 +6,5 @@ export type PaginatedBase = {
     /**
      * Whether or not there are more elements available after this set. If false, this set comprises the end of the array.
      */
-    has_more: boolean
+    hasMore: boolean
 }

--- a/src/models/ProjectSummary.ts
+++ b/src/models/ProjectSummary.ts
@@ -14,7 +14,7 @@ export type ProjectSummary = {
     /**
      * The project's short name. May coincide with name.
      */
-    short_name: string
+    shortName: string
     /**
      * Project slug
      */
@@ -26,15 +26,15 @@ export type ProjectSummary = {
     /**
      * The project's offset type, eg Forest conservation, Afforestation, Direct Air Capture
      */
-    project_type: string
+    projectType: string
     /**
      * The project's Verification Standard Entity name or equivalent organization.
      */
-    registry_name: string
+    registryName: string
     /**
      * A link to the registry's project details page.
      */
-    registry_link?: string
+    registryLink: string
     /**
      * Latitude
      */
@@ -46,11 +46,11 @@ export type ProjectSummary = {
     /**
      * The project's country
      */
-    country_name: string
+    countryName: string
     /**
      * The project's 3 character country code
      */
-    country_code: string
+    countryCode: string
     /**
      * The project's region
      */
@@ -58,11 +58,11 @@ export type ProjectSummary = {
     /**
      * A project image URL
      */
-    primary_image?: string
+    primaryImage: string
     /**
      * A project thumbnail image URL
      */
-    thumbnail_image?: string
+    thumbnailImage: string
     /**
      * Project results
      */
@@ -73,7 +73,7 @@ export type ProjectSummary = {
      * Each number in the array represent one UN Sustainable Development Goal. See https://sdgs.un.org/goals.
      *
      */
-    un_sdg?: Array<number>
+    unSdg: Array<number>
     /**
      * Disabled projects do not get allocated to orders
      *

--- a/src/models/RoRoSeaShippingMethod.ts
+++ b/src/models/RoRoSeaShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 export type RoRoSeaShippingMethod = {
-    vessel_type: 'sea_roro'
+    vesselType: 'sea_roro'
     fuel?: 'HFO' | 'MGO'
     load?: 'freight_only' | 'truck_and_trailer' | 'trailer_only'
 }

--- a/src/models/Shipment.ts
+++ b/src/models/Shipment.ts
@@ -18,5 +18,5 @@ export type Shipment =
       }
     | {
           containers: string
-          cargo_type?: 'lightweight' | 'average' | 'heavyweight' | 'container_only'
+          cargoType: 'lightweight' | 'average' | 'heavyweight' | 'container_only'
       }

--- a/src/models/ShippingEstimateRequest.ts
+++ b/src/models/ShippingEstimateRequest.ts
@@ -25,5 +25,5 @@ export type ShippingEstimateRequest = {
      * the country with the largest share of the route.
      *
      */
-    country_code?: string
+    countryCode: string
 }

--- a/src/models/VariableFuelSeaShippingMethod.ts
+++ b/src/models/VariableFuelSeaShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 export type VariableFuelSeaShippingMethod = {
-    vessel_type:
+    vesselType:
         | 'sea_oil_tanker_small'
         | 'sea_oil_tanker_medium'
         | 'sea_oil_tanker_large'

--- a/src/models/VariableFuelVariableLoadSeaShippingMethod.ts
+++ b/src/models/VariableFuelVariableLoadSeaShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 export type VariableFuelVariableLoadSeaShippingMethod = {
-    vessel_type: 'sea_bulk_carrier_medium' | 'sea_bulk_carrier_large'
+    vesselType: 'sea_bulk_carrier_medium' | 'sea_bulk_carrier_large'
     fuel?: 'HFO' | 'MGO'
     load?: 'average' | 'heavy'
 }

--- a/src/models/WebhookEvent.ts
+++ b/src/models/WebhookEvent.ts
@@ -9,15 +9,15 @@ export type WebhookEvent = {
      * Version of the API that serialized the event. The only possible value at the moment is `v1`.
      *
      */
-    api_version: string
+    apiVersion: string
     /**
      * The event’s id. The id can be used for idempotency behaviour if stored on the client side.
      */
-    event_id: string
+    eventId: string
     /**
      * The event type. The type of event data will depend on the value present here.
      */
-    event_type:
+    eventType:
         | 'order.received'
         | 'order.placed'
         | 'order.allocated'

--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,8 @@
   "readme": "README.md",
   "dependencies": {
     "axios": "^0.21.1",
+    "camelcase-keys": "^7.0.2",
+    "snakecase-keys": "^5.1.2",
     "ts-results-es": "^3.4.0"
   }
 }

--- a/src/schemas/$Account.ts
+++ b/src/schemas/$Account.ts
@@ -13,7 +13,7 @@ export const $Account = {
             description: `The Account's name`,
             isRequired: true,
         },
-        organisation_id: {
+        organisationId: {
             type: 'string',
             description: `The unique identifier of the organisation this account belongs to`,
             isRequired: true,
@@ -32,7 +32,7 @@ export const $Account = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        balance_outstanding: {
+        balanceOutstanding: {
             type: 'string',
             description: `The Account's outstanding balance represents the sum of placed and unpaid orders.
 

--- a/src/schemas/$Activity.ts
+++ b/src/schemas/$Activity.ts
@@ -29,18 +29,18 @@ export const $Activity = {
             isRequired: true,
             pattern: '^-?[0-9]+(\\.[0-9]+)?$',
         },
-        balance_delta: {
+        balanceDelta: {
             type: 'string',
             description: `Account's cash balance delta.
 
-            The previous balance plus \`balance_delta\` equals the current balance.
+            The previous balance plus \`balanceDelta\` equals the current balance.
 
             Unit: Account currency
             `,
             isRequired: true,
             pattern: '^-?[0-9]+(\\.[0-9]+)?$',
         },
-        balance_outstanding: {
+        balanceOutstanding: {
             type: 'string',
             description: `The Account's outstanding balance at the time of this activity
 
@@ -49,11 +49,11 @@ export const $Activity = {
             isRequired: true,
             pattern: '^-?[0-9]+(\\.[0-9]+)?$',
         },
-        balance_outstanding_delta: {
+        balanceOutstandingDelta: {
             type: 'string',
             description: `Account's outstanding balance delta.
 
-            The previous outstanding balance plus \`balance_outstanding_delta\` equals the current outstanding balance.
+            The previous outstanding balance plus \`balanceOutstandingDelta\` equals the current outstanding balance.
 
             Unit: Account currency
             `,
@@ -65,19 +65,19 @@ export const $Activity = {
             description: `Quantity of CO2 offsets linked to this activity (tonnes CO2)`,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        order_id: {
+        orderId: {
             type: 'string',
             description: `The order's unique identifier`,
         },
-        project_id: {
+        projectId: {
             type: 'string',
             description: `The project's unique identifier`,
         },
-        project_name: {
+        projectName: {
             type: 'string',
             description: `The project's name`,
         },
-        created_at: {
+        createdAt: {
             type: 'string',
             description: `Activity creation timestamp`,
             isRequired: true,

--- a/src/schemas/$Address.ts
+++ b/src/schemas/$Address.ts
@@ -3,12 +3,12 @@
 /* eslint-disable */
 export const $Address = {
     properties: {
-        street_line1: {
+        streetLine1: {
             type: 'string',
             description: `A street and house number (or equivalent).`,
             isRequired: true,
         },
-        street_line2: {
+        streetLine2: {
             type: 'string',
             description: `An address component more precise than a street and house number.`,
         },
@@ -21,7 +21,7 @@ export const $Address = {
             type: 'string',
             isRequired: true,
         },
-        country_code: {
+        countryCode: {
             type: 'string',
             description: `A three-letter country code.`,
             isRequired: true,

--- a/src/schemas/$Analytics.ts
+++ b/src/schemas/$Analytics.ts
@@ -3,52 +3,52 @@
 /* eslint-disable */
 export const $Analytics = {
     properties: {
-        total_completed_offset_value: {
+        totalCompletedOffsetValue: {
             type: 'string',
             description: `The total monetary value of all completed orders for a given interval.`,
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        total_completed_offset_quantity: {
+        totalCompletedOffsetQuantity: {
             type: 'string',
             description: `The total quantity in tCO2 of all completed orders for a given interval.`,
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        total_placed_offset_value: {
+        totalPlacedOffsetValue: {
             type: 'string',
             description: `The total monetary value of all placed orders for a given interval.`,
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        total_placed_offset_quantity: {
+        totalPlacedOffsetQuantity: {
             type: 'string',
             description: `The total quantity in tCO2 of all placed orders for a given interval.`,
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        completed_offset_values: {
+        completedOffsetValues: {
             type: 'array',
             contains: {
                 type: 'OffsetValueSeriesItem',
             },
             isRequired: true,
         },
-        completed_offset_quantities: {
+        completedOffsetQuantities: {
             type: 'array',
             contains: {
                 type: 'OffsetQuantitySeriesItem',
             },
             isRequired: true,
         },
-        placed_offset_values: {
+        placedOffsetValues: {
             type: 'array',
             contains: {
                 type: 'OffsetValueSeriesItem',
             },
             isRequired: true,
         },
-        placed_offset_quantities: {
+        placedOffsetQuantities: {
             type: 'array',
             contains: {
                 type: 'OffsetQuantitySeriesItem',

--- a/src/schemas/$BundlePercentage.ts
+++ b/src/schemas/$BundlePercentage.ts
@@ -4,7 +4,7 @@
 export const $BundlePercentage = {
     description: `Maps a bundle id to an allocation ratio`,
     properties: {
-        bundle_id: {
+        bundleId: {
             type: 'string',
             description: `The bundle's unique identifier`,
             isRequired: true,

--- a/src/schemas/$BundlePercentageRequest.ts
+++ b/src/schemas/$BundlePercentageRequest.ts
@@ -4,7 +4,7 @@
 export const $BundlePercentageRequest = {
     description: `Maps a bundle id to an allocation ratio`,
     properties: {
-        bundle_id: {
+        bundleId: {
             type: 'string',
             description: `The bundle's unique identifier`,
             isRequired: true,

--- a/src/schemas/$BundleSummary.ts
+++ b/src/schemas/$BundleSummary.ts
@@ -13,14 +13,14 @@ export const $BundleSummary = {
             description: `The bundle's name`,
             isRequired: true,
         },
-        unit_price: {
+        unitPrice: {
             type: 'string',
             description: `Bundle unit price per tonne CO2
             `,
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        gross_unit_price: {
+        grossUnitPrice: {
             type: 'string',
             description: `Bundle unit price per tonne CO2 inclusive of fees
             `,
@@ -32,11 +32,11 @@ export const $BundleSummary = {
             description: `Currency code`,
             isRequired: true,
         },
-        primary_image: {
+        primaryImage: {
             type: 'string',
             description: `A bundle's image URL`,
         },
-        primary_image_hires: {
+        primaryImageHires: {
             type: 'string',
             description: `A bundle's high resolution image URL`,
         },
@@ -50,15 +50,15 @@ export const $BundleSummary = {
             `,
             isRequired: true,
         },
-        available_quantity: {
+        availableQuantity: {
             type: 'string',
             description: `Quantity of CO2 offsets available to purchase (in tonnes).
 
-            If available_quantity is not set, assume there is an unlimited amount of offsets to purchase.
+            If availableQuantity is not set, assume there is an unlimited amount of offsets to purchase.
             `,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        offset_type: {
+        offsetType: {
             type: 'Enum',
         },
     },

--- a/src/schemas/$CompanyEmissionEstimate.ts
+++ b/src/schemas/$CompanyEmissionEstimate.ts
@@ -26,7 +26,7 @@ export const $CompanyEmissionEstimate = {
                 },
                 components: {
                     properties: {
-                        material_and_waste: {
+                        materialAndWaste: {
                             type: 'Mass',
                             description: `Emissions associated with buying equipment and generating waste.`,
                             isRequired: true,
@@ -36,12 +36,12 @@ export const $CompanyEmissionEstimate = {
                             description: `Emissions associated with purchasing energy (electricy, heating etc.)`,
                             isRequired: true,
                         },
-                        travel_and_commute: {
+                        travelAndCommute: {
                             type: 'Mass',
                             description: `Emissions associated with business travels and commuting to/from work.`,
                             isRequired: true,
                         },
-                        food_and_drink: {
+                        foodAndDrink: {
                             type: 'Mass',
                             description: `Emissions associated with food and drinks.`,
                             isRequired: true,

--- a/src/schemas/$CompanyEstimateRequest.ts
+++ b/src/schemas/$CompanyEstimateRequest.ts
@@ -12,17 +12,17 @@ export const $CompanyEstimateRequest = {
             description: `Number of employees`,
             isRequired: true,
         },
-        remote_employees_percentage: {
+        remoteEmployeesPercentage: {
             type: 'IntegerPercentage',
             description: `Share of employees working remotely (in percent)`,
             isRequired: true,
         },
-        office_area: {
+        officeArea: {
             type: 'Area',
             description: `Office area in square meters`,
             isRequired: true,
         },
-        country_code: {
+        countryCode: {
             type: 'string',
             description: `The three-letter country code of the country where the company is located.`,
             isRequired: true,
@@ -34,67 +34,67 @@ export const $CompanyEstimateRequest = {
         city: {
             type: 'string',
         },
-        electricity_consumption: {
+        electricityConsumption: {
             type: 'number',
             description: `Electricity consumption in kWh`,
             isRequired: true,
         },
-        green_electricity_used: {
+        greenElectricityUsed: {
             type: 'boolean',
             description: `Is the electricity provided by renewable source(s)?`,
             isRequired: true,
         },
-        gas_consumption: {
+        gasConsumption: {
             type: 'number',
             description: `Yearly natural gas consumption in cubic meters`,
             isRequired: true,
         },
-        company_cars: {
+        companyCars: {
             type: 'number',
             description: `Company cars`,
             isRequired: true,
         },
-        average_car_distance_travelled: {
+        averageCarDistanceTravelled: {
             type: 'Distance',
             description: `Average yearly distance travelled per car`,
             isRequired: true,
         },
-        employees_using_public_transport: {
+        employeesUsingPublicTransport: {
             type: 'number',
             description: `Number of employees commuting by public transport`,
             isRequired: true,
         },
-        short_flights: {
+        shortFlights: {
             type: 'number',
             description: `Number of short (under 3 hours) flights per year`,
             isRequired: true,
         },
-        medium_flights: {
+        mediumFlights: {
             type: 'number',
             description: `Number of medium (between 3 and 6 hours) flights per year`,
             isRequired: true,
         },
-        long_flights: {
+        longFlights: {
             type: 'number',
             description: `Number of long (over 6 hours) flights per year`,
             isRequired: true,
         },
-        first_or_business_class_percentage: {
+        firstOrBusinessClassPercentage: {
             type: 'IntegerPercentage',
             description: `Share of business or first class flights, in percent`,
             isRequired: true,
         },
-        food_and_drinks_expenses: {
+        foodAndDrinksExpenses: {
             type: 'MonetaryAmount',
             description: `Amount spend on food and drinks`,
             isRequired: true,
         },
-        vegetarian_and_vegan_percentage: {
+        vegetarianAndVeganPercentage: {
             type: 'IntegerPercentage',
             description: `Share of vegetarians or vegans in the company, in percent`,
             isRequired: true,
         },
-        electronic_device_expenses: {
+        electronicDeviceExpenses: {
             type: 'MonetaryAmount',
             description: `New electronic devices (laptops, monitors, etc.) expenses`,
             isRequired: true,
@@ -104,14 +104,14 @@ export const $CompanyEstimateRequest = {
             description: `The amount of garbage produced, in kilograms`,
             isRequired: true,
         },
-        recycled_garbage_percentage: {
+        recycledGarbagePercentage: {
             type: 'IntegerPercentage',
             description: `Share of recycled garbage, in percent`,
             isRequired: true,
         },
         tech: {
             properties: {
-                on_premise: {
+                onPremise: {
                     type: 'CompanyOnPremiseUse',
                 },
                 cloud: {

--- a/src/schemas/$CompanyOnPremiseUse.ts
+++ b/src/schemas/$CompanyOnPremiseUse.ts
@@ -4,7 +4,7 @@
 export const $CompanyOnPremiseUse = {
     description: `Company's own tech infrastructure details`,
     properties: {
-        electricity_cost: {
+        electricityCost: {
             type: 'MonetaryAmount',
             isRequired: true,
         },

--- a/src/schemas/$ContainerShippingMethod.ts
+++ b/src/schemas/$ContainerShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $ContainerShippingMethod = {
     properties: {
-        vessel_type: {
+        vesselType: {
             type: 'Enum',
             isRequired: true,
         },
@@ -15,7 +15,7 @@ export const $ContainerShippingMethod = {
             This parameter defaults to \`true\`.
             `,
         },
-        trade_lane: {
+        tradeLane: {
             type: 'Enum',
         },
     },

--- a/src/schemas/$CreateOrderByQuantityRequest.ts
+++ b/src/schemas/$CreateOrderByQuantityRequest.ts
@@ -14,17 +14,17 @@ export const $CreateOrderByQuantityRequest = {
             ],
             isRequired: true,
         },
-        idempotency_key: {
+        idempotencyKey: {
             type: 'string',
             description: `Optional unique identifier provided by the client.
 
-            \`idempotency_key\` has two purposes:
+            \`idempotencyKey\` has two purposes:
             1. Clients can safely retry order requests without accidentally performing the same operation twice. The current state of the original order is returned.
-            2. Clients can use \`idempotency_key\` to reconcile orders with other entities on their system.
+            2. Clients can use \`idempotencyKey\` to reconcile orders with other entities on their system.
             `,
             maxLength: 100,
         },
-        bundle_selection: {
+        bundleSelection: {
             type: 'BundleSelectionRequest',
         },
         metadata: {

--- a/src/schemas/$CreateOrderByValueRequest.ts
+++ b/src/schemas/$CreateOrderByValueRequest.ts
@@ -10,17 +10,17 @@ export const $CreateOrderByValueRequest = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        idempotency_key: {
+        idempotencyKey: {
             type: 'string',
             description: `Optional unique identifier provided by the client.
 
-            \`idempotency_key\` has two purposes:
+            \`idempotencyKey\` has two purposes:
             1. Clients can safely retry order requests without accidentally performing the same operation twice. The current state of the original order is returned.
-            2. Clients can use \`idempotency_key\` to reconcile orders with other entities on their system.
+            2. Clients can use \`idempotencyKey\` to reconcile orders with other entities on their system.
             `,
             maxLength: 100,
         },
-        bundle_selection: {
+        bundleSelection: {
             type: 'BundleSelectionRequest',
         },
         metadata: {

--- a/src/schemas/$ElectricityEstimateRequest.ts
+++ b/src/schemas/$ElectricityEstimateRequest.ts
@@ -8,7 +8,7 @@ export const $ElectricityEstimateRequest = {
             type: 'ElectricityConsumption',
             isRequired: true,
         },
-        country_code: {
+        countryCode: {
             type: 'string',
             description: `The three-letter code of the country where the consumption takes place, if applicable.
 

--- a/src/schemas/$Error.ts
+++ b/src/schemas/$Error.ts
@@ -4,7 +4,7 @@
 export const $Error = {
     description: `Individual error information`,
     properties: {
-        error_code: {
+        errorCode: {
             type: 'Enum',
             isRequired: true,
         },

--- a/src/schemas/$FlightEstimateRequest.ts
+++ b/src/schemas/$FlightEstimateRequest.ts
@@ -17,7 +17,7 @@ export const $FlightEstimateRequest = {
             ],
             isRequired: true,
         },
-        cabin_class: {
+        cabinClass: {
             type: 'CabinClass',
         },
         passengers: {

--- a/src/schemas/$HugeOilTankerSeaShippingMethod.ts
+++ b/src/schemas/$HugeOilTankerSeaShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $HugeOilTankerSeaShippingMethod = {
     properties: {
-        vessel_type: {
+        vesselType: {
             type: 'Enum',
             isRequired: true,
         },

--- a/src/schemas/$IdentifiedVesselShippingMethod.ts
+++ b/src/schemas/$IdentifiedVesselShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $IdentifiedVesselShippingMethod = {
     properties: {
-        vessel_imo_number: {
+        vesselImoNumber: {
             type: 'string',
             description: `The ship's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the \`IMO\` prefix.
             `,

--- a/src/schemas/$Merchant.ts
+++ b/src/schemas/$Merchant.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $Merchant = {
     properties: {
-        category_code: {
+        categoryCode: {
             type: 'string',
             description: `An ISO 18245 Merchant Category Code (leading zeros need to be preserved) corresponding
             to the transaction.
@@ -16,7 +16,7 @@ export const $Merchant = {
             type: 'string',
             description: `The name of the merchant.`,
         },
-        country_code: {
+        countryCode: {
             type: 'string',
             description: `The three-letter code of the merchant's country.`,
             isRequired: true,

--- a/src/schemas/$OffsetLink.ts
+++ b/src/schemas/$OffsetLink.ts
@@ -37,7 +37,7 @@ export const $OffsetLink = {
             This is the logo URL that appears on the first screen of the offset links flow.
             `,
         },
-        use_logo: {
+        useLogo: {
             type: 'boolean',
             description: `Whether to include the Offset link logo (defined in Account settings) in the footer.
             `,
@@ -67,7 +67,7 @@ export const $OffsetLink = {
                 type: 'Bundle',
             },
         },
-        created_at: {
+        createdAt: {
             type: 'Timestamp',
             isRequired: true,
         },
@@ -75,10 +75,10 @@ export const $OffsetLink = {
             type: 'OffsetLinkStatus',
             isRequired: true,
         },
-        expires_at: {
+        expiresAt: {
             type: 'Timestamp',
         },
-        require_payment: {
+        requirePayment: {
             type: 'boolean',
             description: `If true, the user of the Offset Link is required to pay by credit/debit card.
             `,

--- a/src/schemas/$OffsetLinkAnalytics.ts
+++ b/src/schemas/$OffsetLinkAnalytics.ts
@@ -8,12 +8,12 @@ export const $OffsetLinkAnalytics = {
             description: `The offset link identifier`,
             isRequired: true,
         },
-        unique_visitors: {
+        uniqueVisitors: {
             type: 'number',
             description: `The number of unique visitors for the specific offset link`,
             isRequired: true,
         },
-        placed_orders: {
+        placedOrders: {
             type: 'number',
             description: `The number of placed orders for the specific offset link`,
             isRequired: true,

--- a/src/schemas/$OffsetLinkOrder.ts
+++ b/src/schemas/$OffsetLinkOrder.ts
@@ -3,12 +3,12 @@
 /* eslint-disable */
 export const $OffsetLinkOrder = {
     properties: {
-        order_id: {
+        orderId: {
             type: 'string',
             description: `The order's unique identifier`,
             isRequired: true,
         },
-        created_at: {
+        createdAt: {
             type: 'Timestamp',
             isRequired: true,
         },
@@ -21,12 +21,12 @@ export const $OffsetLinkOrder = {
             type: 'array',
             contains: {
                 properties: {
-                    bundle_id: {
+                    bundleId: {
                         type: 'string',
                         description: `The bundle's unique identifier`,
                         isRequired: true,
                     },
-                    bundle_name: {
+                    bundleName: {
                         type: 'string',
                         description: `The bundle's name`,
                         isRequired: true,

--- a/src/schemas/$OffsetLinkRequest.ts
+++ b/src/schemas/$OffsetLinkRequest.ts
@@ -40,16 +40,16 @@ export const $OffsetLinkRequest = {
                 type: 'string',
             },
         },
-        expires_at: {
+        expiresAt: {
             type: 'Timestamp',
         },
-        use_logo: {
+        useLogo: {
             type: 'boolean',
             description: `Whether to include the Offset link logo (defined in Account settings) in the footer.
             `,
             isRequired: true,
         },
-        require_payment: {
+        requirePayment: {
             type: 'boolean',
             description: `If true, the user of the Offset Link is required to pay by credit/debit card.
             This value cannot be updated once the offset link has been created.

--- a/src/schemas/$OffsetLinkUpdateRequest.ts
+++ b/src/schemas/$OffsetLinkUpdateRequest.ts
@@ -40,10 +40,10 @@ export const $OffsetLinkUpdateRequest = {
                 type: 'string',
             },
         },
-        expires_at: {
+        expiresAt: {
             type: 'Timestamp',
         },
-        use_logo: {
+        useLogo: {
             type: 'boolean',
             description: `Whether to include the Offset link logo (defined in Account settings) in the footer.
             `,

--- a/src/schemas/$OrderBase.ts
+++ b/src/schemas/$OrderBase.ts
@@ -9,13 +9,13 @@ export const $OrderBase = {
             description: `The order's unique identifier`,
             isRequired: true,
         },
-        idempotency_key: {
+        idempotencyKey: {
             type: 'string',
             description: `Optional unique identifier provided by the client.
 
-            \`idempotency_key\` has two purposes:
+            \`idempotencyKey\` has two purposes:
             1. Clients can safely retry order requests without accidentally performing the same operation twice. The current state of the original order is returned.
-            2. Clients can use \`idempotency_key\` to reconcile orders with other entities on their system.
+            2. Clients can use \`idempotencyKey\` to reconcile orders with other entities on their system.
             `,
             maxLength: 100,
         },
@@ -32,7 +32,7 @@ export const $OrderBase = {
             description: `Order currency code`,
             isRequired: true,
         },
-        offset_cost: {
+        offsetCost: {
             type: 'string',
             description: `Represents the net cost of offsets purchased by the order. May be lower than \`requested_value\`.
 
@@ -44,7 +44,7 @@ export const $OrderBase = {
             `,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        total_cost: {
+        totalCost: {
             type: 'string',
             description: `The total cost for the order inclusive of fees.
 
@@ -69,7 +69,7 @@ export const $OrderBase = {
             description: `Quantity of CO2 offsets purchased in tonnes.`,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        created_at: {
+        createdAt: {
             type: 'string',
             description: `Order creation timestamp`,
             isRequired: true,
@@ -98,7 +98,7 @@ export const $OrderBase = {
             type: 'Metadata',
             isRequired: true,
         },
-        offset_link_id: {
+        offsetLinkId: {
             type: 'string',
             description: `The offset link identifier, if the order was placed through an offset link`,
         },

--- a/src/schemas/$OrderBundle.ts
+++ b/src/schemas/$OrderBundle.ts
@@ -3,12 +3,12 @@
 /* eslint-disable */
 export const $OrderBundle = {
     properties: {
-        bundle_id: {
+        bundleId: {
             type: 'string',
             description: `The bundle's unique identifier`,
             isRequired: true,
         },
-        bundle_name: {
+        bundleName: {
             type: 'string',
             description: `The bundle's name`,
             isRequired: true,
@@ -19,7 +19,7 @@ export const $OrderBundle = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        unit_price: {
+        unitPrice: {
             type: 'string',
             description: `Bundle unit price per tonne CO2
 
@@ -28,7 +28,7 @@ export const $OrderBundle = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        gross_unit_price: {
+        grossUnitPrice: {
             type: 'string',
             description: `Bundle unit price per tonne CO2 inclusive of fees.
 
@@ -37,7 +37,7 @@ export const $OrderBundle = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        offset_cost: {
+        offsetCost: {
             type: 'string',
             description: `Represents the net cost of offsets purchased by the order for this bundle.
 
@@ -46,7 +46,7 @@ export const $OrderBundle = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        insufficient_available_quantity: {
+        insufficientAvailableQuantity: {
             type: 'boolean',
             description: `If true, there is no inventory necessary to fully satisfy the order for this bundle.
             `,

--- a/src/schemas/$OrderByQuantity.ts
+++ b/src/schemas/$OrderByQuantity.ts
@@ -9,7 +9,7 @@ export const $OrderByQuantity = {
         },
         {
             properties: {
-                requested_quantity: {
+                requestedQuantity: {
                     type: 'string',
                     description: `Represents the requested quantity of CO2 offsets to purchase in tonnes.`,
                     isRequired: true,

--- a/src/schemas/$OrderByValue.ts
+++ b/src/schemas/$OrderByValue.ts
@@ -9,7 +9,7 @@ export const $OrderByValue = {
         },
         {
             properties: {
-                requested_value: {
+                requestedValue: {
                     type: 'string',
                     description: `Represents the requested value of CO2 offsets to purchase.
 

--- a/src/schemas/$OrderProject.ts
+++ b/src/schemas/$OrderProject.ts
@@ -3,22 +3,22 @@
 /* eslint-disable */
 export const $OrderProject = {
     properties: {
-        project_id: {
+        projectId: {
             type: 'string',
             description: `The project's unique identifier`,
             isRequired: true,
         },
-        project_name: {
+        projectName: {
             type: 'string',
             description: `The project's name`,
             isRequired: true,
         },
-        project_type: {
+        projectType: {
             type: 'string',
             description: `The project's offset type, eg Forest conservation, Afforestation, Direct Air Capture`,
             isRequired: true,
         },
-        project_slug: {
+        projectSlug: {
             type: 'string',
             description: `The project's unique slug`,
             isRequired: true,
@@ -29,7 +29,7 @@ export const $OrderProject = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        unit_price: {
+        unitPrice: {
             type: 'string',
             description: `Project unit price per tonne CO2
 
@@ -38,7 +38,7 @@ export const $OrderProject = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        offset_cost: {
+        offsetCost: {
             type: 'string',
             description: `Represents the net cost of offsets purchased by the order for this project.
 

--- a/src/schemas/$OrderQuoteBase.ts
+++ b/src/schemas/$OrderQuoteBase.ts
@@ -8,7 +8,7 @@ export const $OrderQuoteBase = {
             description: `Currency code`,
             isRequired: true,
         },
-        estimated_quantity: {
+        estimatedQuantity: {
             type: 'string',
             description: `Estimated quantity (tonnes CO2).
 
@@ -17,7 +17,7 @@ export const $OrderQuoteBase = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        estimated_offset_cost: {
+        estimatedOffsetCost: {
             type: 'string',
             description: `Estimated offset cost
 
@@ -26,7 +26,7 @@ export const $OrderQuoteBase = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        estimated_total_cost: {
+        estimatedTotalCost: {
             type: 'string',
             description: `Estimated total cost inclusive of Lune fees.
 
@@ -35,7 +35,7 @@ export const $OrderQuoteBase = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        estimated_commission: {
+        estimatedCommission: {
             type: 'string',
             description: `Estimated commission`,
             isRequired: true,

--- a/src/schemas/$OrderQuoteByQuantity.ts
+++ b/src/schemas/$OrderQuoteByQuantity.ts
@@ -9,7 +9,7 @@ export const $OrderQuoteByQuantity = {
         },
         {
             properties: {
-                requested_quantity: {
+                requestedQuantity: {
                     type: 'string',
                     description: `Requested quantity for the specific bundle (tonnes CO2)`,
                     isRequired: true,

--- a/src/schemas/$OrderQuoteByQuantityRequest.ts
+++ b/src/schemas/$OrderQuoteByQuantityRequest.ts
@@ -14,7 +14,7 @@ export const $OrderQuoteByQuantityRequest = {
             ],
             isRequired: true,
         },
-        bundle_selection: {
+        bundleSelection: {
             type: 'BundleSelectionRequest',
         },
     },

--- a/src/schemas/$OrderQuoteByValue.ts
+++ b/src/schemas/$OrderQuoteByValue.ts
@@ -9,7 +9,7 @@ export const $OrderQuoteByValue = {
         },
         {
             properties: {
-                requested_value: {
+                requestedValue: {
                     type: 'string',
                     description: `Requested order value inclusive of commission`,
                     isRequired: true,

--- a/src/schemas/$OrderQuoteByValueRequest.ts
+++ b/src/schemas/$OrderQuoteByValueRequest.ts
@@ -10,7 +10,7 @@ export const $OrderQuoteByValueRequest = {
             isRequired: true,
             pattern: '^[0-9]+(\\.[0-9]+)?$',
         },
-        bundle_selection: {
+        bundleSelection: {
             type: 'BundleSelectionRequest',
         },
     },

--- a/src/schemas/$PaginatedBase.ts
+++ b/src/schemas/$PaginatedBase.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $PaginatedBase = {
     properties: {
-        has_more: {
+        hasMore: {
             type: 'boolean',
             description: `Whether or not there are more elements available after this set. If false, this set comprises the end of the array.`,
             isRequired: true,

--- a/src/schemas/$ProjectSummary.ts
+++ b/src/schemas/$ProjectSummary.ts
@@ -13,7 +13,7 @@ export const $ProjectSummary = {
             description: `The project's name`,
             isRequired: true,
         },
-        short_name: {
+        shortName: {
             type: 'string',
             description: `The project's short name. May coincide with name.`,
             isRequired: true,
@@ -28,17 +28,17 @@ export const $ProjectSummary = {
             description: `Project description`,
             isRequired: true,
         },
-        project_type: {
+        projectType: {
             type: 'string',
             description: `The project's offset type, eg Forest conservation, Afforestation, Direct Air Capture`,
             isRequired: true,
         },
-        registry_name: {
+        registryName: {
             type: 'string',
             description: `The project's Verification Standard Entity name or equivalent organization.`,
             isRequired: true,
         },
-        registry_link: {
+        registryLink: {
             type: 'string',
             description: `A link to the registry's project details page.`,
         },
@@ -54,12 +54,12 @@ export const $ProjectSummary = {
             isRequired: true,
             format: 'float',
         },
-        country_name: {
+        countryName: {
             type: 'string',
             description: `The project's country`,
             isRequired: true,
         },
-        country_code: {
+        countryCode: {
             type: 'string',
             description: `The project's 3 character country code`,
             isRequired: true,
@@ -68,11 +68,11 @@ export const $ProjectSummary = {
             type: 'string',
             description: `The project's region`,
         },
-        primary_image: {
+        primaryImage: {
             type: 'string',
             description: `A project image URL`,
         },
-        thumbnail_image: {
+        thumbnailImage: {
             type: 'string',
             description: `A project thumbnail image URL`,
         },
@@ -82,7 +82,7 @@ export const $ProjectSummary = {
                 type: 'string',
             },
         },
-        un_sdg: {
+        unSdg: {
             type: 'array',
             contains: {
                 type: 'number',

--- a/src/schemas/$RoRoSeaShippingMethod.ts
+++ b/src/schemas/$RoRoSeaShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $RoRoSeaShippingMethod = {
     properties: {
-        vessel_type: {
+        vesselType: {
             type: 'Enum',
             isRequired: true,
         },

--- a/src/schemas/$Shipment.ts
+++ b/src/schemas/$Shipment.ts
@@ -25,7 +25,7 @@ export const $Shipment = {
                     isRequired: true,
                     pattern: '^[0-9]+(\\.[0-9]+)?$',
                 },
-                cargo_type: {
+                cargoType: {
                     type: 'Enum',
                 },
             },

--- a/src/schemas/$ShippingEstimateRequest.ts
+++ b/src/schemas/$ShippingEstimateRequest.ts
@@ -25,7 +25,7 @@ export const $ShippingEstimateRequest = {
             type: 'ShippingMethod',
             isRequired: true,
         },
-        country_code: {
+        countryCode: {
             type: 'string',
             description: `The three-letter code of the country where the shipping takes place, if applicable.
 

--- a/src/schemas/$VariableFuelSeaShippingMethod.ts
+++ b/src/schemas/$VariableFuelSeaShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $VariableFuelSeaShippingMethod = {
     properties: {
-        vessel_type: {
+        vesselType: {
             type: 'Enum',
             isRequired: true,
         },

--- a/src/schemas/$VariableFuelVariableLoadSeaShippingMethod.ts
+++ b/src/schemas/$VariableFuelVariableLoadSeaShippingMethod.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $VariableFuelVariableLoadSeaShippingMethod = {
     properties: {
-        vessel_type: {
+        vesselType: {
             type: 'Enum',
             isRequired: true,
         },

--- a/src/schemas/$WebhookEvent.ts
+++ b/src/schemas/$WebhookEvent.ts
@@ -3,18 +3,18 @@
 /* eslint-disable */
 export const $WebhookEvent = {
     properties: {
-        api_version: {
+        apiVersion: {
             type: 'string',
             description: `Version of the API that serialized the event. The only possible value at the moment is \`v1\`.
             `,
             isRequired: true,
         },
-        event_id: {
+        eventId: {
             type: 'string',
             description: `The event’s id. The id can be used for idempotency behaviour if stored on the client side.`,
             isRequired: true,
         },
-        event_type: {
+        eventType: {
             type: 'Enum',
             isRequired: true,
         },

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -14,7 +14,9 @@
     "noImplicitThis": true,
     "noImplicitAny": false,
     "baseUrl": "./",
-    "target": "ES2019"
+    "target": "ES2019",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts", "./dist"]


### PR DESCRIPTION
The API has parameters following the snake_case convention. This is the
usual scenario on API's so we want to keep it. However, the TS/JS
ecosystem usually goes for camelCase. Hence, we now convert all
parameters in the generated models and schemas to camelCase.

This is done in a similar manner as fixing the services is, via seds on
the files we want affected.

At this point, I do agree that I might have gone a bit overboard with the
complexity introduced on the Makefile to produce the actual desired
format of the client. It might have been more beneficial to modify the
generator tool to better suit our needs, but I wasn't expecting so many
changes at the start of building the client. For now, I think it's better to
stick to the current way and in the future we might explore the base
generation tool and move these changes to be made at the source.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>