### PR TITLE
Use lune fork for base generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build:
 	npm run build
 
 api-schema:
-	npx openapi-typescript-codegen -i https://docs.lune.co/openapi.yml --output src --useUnionTypes --exportCore false --exportServices true --exportSchemas true
+	npx @lune-climate/openapi-typescript-codegen -i https://docs.lune.co/openapi.yml --output src --useUnionTypes --exportCore false --exportServices true --exportSchemas true
 
 # This fixes the generated service files. See README.md for more info
 SERVICES_DIR = ./src/services

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ts-results-es": "^3.4.0"
       },
       "devDependencies": {
+        "@lune-climate/openapi-typescript-codegen": "^0.0.1",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "eslint": "^7.32.0",
@@ -23,7 +24,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^5.2.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
-        "openapi-typescript-codegen": "^0.20.1",
         "prettier": "^2.5.1",
         "typescript": "^4.6.2"
       }
@@ -215,6 +215,21 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
+    },
+    "node_modules/@lune-climate/openapi-typescript-codegen": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.0.1.tgz",
+      "integrity": "sha512-oCWKkvaj49aqSiBc0vT05YNzqRxVnx0ZO8EdKpkBj50jww+7m2J8s9E4TugoOJ6YWcSEyXIpJLbyCAZpyjSacA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "commander": "^9.0.0",
+        "handlebars": "^4.7.7",
+        "json-schema-ref-parser": "^9.0.9"
+      },
+      "bin": {
+        "openapi": "bin/index.js"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2158,21 +2173,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/openapi-typescript-codegen": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.20.1.tgz",
-      "integrity": "sha512-07Fn/es5a3G696tyqkukmgOr/xH3vGnAp32dQO1mb4mSWmIEgtkMtjm+p7htphGhH0jLX1ruPaGfzU+WkdvIGw==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^6.3.0",
-        "commander": "^9.0.0",
-        "handlebars": "^4.7.7",
-        "json-schema-ref-parser": "^9.0.9"
-      },
-      "bin": {
-        "openapi": "bin/index.js"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -3028,6 +3028,18 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
+    },
+    "@lune-climate/openapi-typescript-codegen": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.0.1.tgz",
+      "integrity": "sha512-oCWKkvaj49aqSiBc0vT05YNzqRxVnx0ZO8EdKpkBj50jww+7m2J8s9E4TugoOJ6YWcSEyXIpJLbyCAZpyjSacA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.3.0",
+        "commander": "^9.0.0",
+        "handlebars": "^4.7.7",
+        "json-schema-ref-parser": "^9.0.9"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4411,18 +4423,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "openapi-typescript-codegen": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.20.1.tgz",
-      "integrity": "sha512-07Fn/es5a3G696tyqkukmgOr/xH3vGnAp32dQO1mb4mSWmIEgtkMtjm+p7htphGhH0jLX1ruPaGfzU+WkdvIGw==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^6.3.0",
-        "commander": "^9.0.0",
-        "handlebars": "^4.7.7",
-        "json-schema-ref-parser": "^9.0.9"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ts-results-es": "^3.4.0"
   },
   "devDependencies": {
-    "openapi-typescript-codegen": "^0.20.1",
+    "@lune-climate/openapi-typescript-codegen": "^0.0.1",
     "typescript": "^4.6.2",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",


### PR DESCRIPTION
Instead of using the original openapi-typescript-generator package, we
want to use the custom fork we've created to be able to provide with
base models and services that better fit our needs. For now, the initial
version is an exact replicate of the original behaviour so no changes in
the code itself are made.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>