### PR TITLE
Fix workflow to open automatic PR on schema change

### DIFF
--- a/.github/workflows/rebuild-schema.yml
+++ b/.github/workflows/rebuild-schema.yml
@@ -28,6 +28,7 @@ jobs:
           title: 'Client auto update'
           body: |
             Underlying schema has changed. Check changes and approve accordingly. This will not create any release, simply assimilate changes on the schema.
+            version change this is.
           labels: |
             Schema Rebuild
             Automated PR


### PR DESCRIPTION
There was an issue with the workflow itself. The secret we were
referencing was wrong. The description had multiline, which I believe
is not an issue but better safe than sorry. This should make the rebuild
correctly open the PR.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>