### PR TITLE
Add helper methods for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ build-final-client: move-client
 # Full build of the client from the openapi schema. Use this whenever the openapi schema is updated
 build-from-schema: install api-schema build-final-client fix-linting build
 
+# Fast build of the client from the openapi schema. Used for development purposes when installing
+# dependencies and linting isn't necessary. Currently used on dashboard to speed regeneration of models.
+development-build-from-schema: api-schema build-final-client build
+
 # Build from source. This makes sure code is acceptable and working
 build-from-source: install check-linting build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,8 @@ services:
     command: bash
     volumes:
       - .:/lune-ts
+  local_model_rebuild:
+    build: .
+    command: bash -c "cd /lune-ts && make development-build-from-schema"
+    volumes:
+      - .:/lune-ts


### PR DESCRIPTION
Add a new command that builds from remote schema without installing
dependencies nor fixing linting. This is to be used to regenerate the
models from the remote schema in the dashboard in a development
environment. It also helps local development in and off itself.
Since this command is only to be used on development, it was added to
the dev docker-compose.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>