### PR TITLE
Pin node version to 16.15.0-deb-1nodesource1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
 RUN wget -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN add-apt-repository "https://deb.nodesource.com/node_16.x buster main"
 RUN apt-get update && apt-get install -y \
-    nodejs=16.14.2-deb-1nodesource1 \
+    nodejs=16.15.0-deb-1nodesource1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /lune-ts


### PR DESCRIPTION
It seems the nodejs=16.14.2-deb-1nodesource1 distribution is not available anymore,
therefore replace it with a newer, but compatible, version.

This fixes the following issue:

```
Step 5/6 : RUN apt-get update && apt-get install -y
nodejs=16.14.2-deb-1nodesource1     && rm -rf /var/lib/apt/lists/*
 ---> Running in 053f696a913c
 Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
 Get:2 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
 Get:3 http://security.debian.org/debian-security buster/updates
 InRelease [65.4 kB]
 Get:4 https://deb.nodesource.com/node_16.x buster InRelease [4584 B]
 Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7911 kB]
 Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages
 [8796 B]
 Get:7 http://security.debian.org/debian-security buster/updates/main
 amd64 Packages [318 kB]
 Get:8 https://deb.nodesource.com/node_16.x buster/main amd64 Packages
 [774 B]
 Fetched 8482 kB in 2s (5557 kB/s)
 Reading package lists...
 W: Skipping acquire of configured file 'buster/binary-amd64/Packages'
 as repository 'https://deb.nodesource.com/node_16.x buster InRelease'
 doesn't have the component 'buster' (component misspelt in
 sources.list?)
 Reading package lists...
 Building dependency tree...
 Reading state information...
 E: Version '16.14.2-deb-1nodesource1' for 'nodejs' was not found
 Service 'update_from_remote_schema' failed to build : The command
 '/bin/sh -c apt-get update && apt-get install -y
 nodejs=16.14.2-deb-1nodesource1     && rm -rf /var/lib/apt/lists/*'
 returned a non-zero code: 100

 Error: Process completed with exit code 1.
```

See https://github.com/lune-climate/lune-ts/runs/6308969466?check_suite_focus=true.