### PR TITLE
Produce new patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lune-climate/lune",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lune-climate/lune",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lune-climate/lune",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Lune Typescript Client",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lune-climate/lune",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Lune Typescript Client",
   "main": "cjs/client.js",
   "module": "esm/client.js",


### PR DESCRIPTION
We want to publish to npm the new changes in the schema.

This simply ups the patch version by one to allow to publish
the package. Full release notes will be on the release itself.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>