### PR TITLE
Add an account switching withAccount() helper

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -53,6 +53,28 @@ export class LuneClient {
     public setAccount(accountId: string) {
         this.config.ACCOUNT = accountId
     }
+
+    /**
+     * Perform an action with the current account being set to a desired one.
+     *
+     * The account will only be overridden for the duration of the action and will be restored
+     * to the previous value at the end (when the result of withAccount() is awaited). The
+     * account is also restored in case of an exception.
+     *
+     * This method modifies the internal state of LuneClient. Calling withAccount() or
+     * setAccount() concurrently from multiple contexts at the same time is not supported and
+     * will result in undefined behavior.
+     */
+    public async withAccount<T>(accountId: string, action: () => Promise<T>): Promise<T> {
+        const previousAccountId = this.config.ACCOUNT
+        try {
+            this.config.ACCOUNT = accountId
+            return await action()
+        }
+        finally {
+            this.config.ACCOUNT = previousAccountId
+        }
+    }
 }
 
 applyMixins(LuneClient, [


### PR DESCRIPTION
We've been seeing this pattern repeatedly in our code:

    const activeId = ...
    try {
        luneClient.setAccount(id)
        const result = await luneClient.somethingSomething()
        doSomethingWithTheResult(result)
    } finally {
        luneClient.setAccount(activeId)
    }

which is annoying (have to keep track of account ids), repetitive
and tricky (we need the finally block to be exception-safe).

The new helper does all that for us and allows us to convert the above
to

    const result = await luneClient.withAccount(id, () => luneClient.somethingSomething())
    doSomethingWithTheResult(result)