### PR TITLE
Revert to the apt-based way of installing Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN wget -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN add-apt-repository "https://deb.nodesource.com/node_16.x buster main"
-# wgetting a specific file instead of installing through apt ensures that we can install
-# older versions of the package even when new ones are published (apt install ... only sees
-# the latest one).
-RUN wget https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_16.15.1-deb-1nodesource1_amd64.deb && \
-    dpkg -i nodejs*.deb && \
-    rm nodejs*.deb
+RUN apt-get update && apt-get install -y \
+    nodejs=16.15.1-deb-1nodesource1 \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /lune-ts


### PR DESCRIPTION
This effectively reverts [1]. [1] broke things in our local environments
as at least some of us use M1 Macs so hardcoded amd64 architecture won't do.

Fixes: [1] 827a87ff34e4 ("Fix Node installation in the Dockerfile (#61)")