### PR TITLE
Use the official Node.js Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,2 @@
-FROM debian:buster-20220125
-RUN apt-get update && apt-get install -y \
-    gnupg \
-      software-properties-common \
-      build-essential \
-      wget \
-      && rm -rf /var/lib/apt/lists/*
-
-RUN wget -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-RUN add-apt-repository "https://deb.nodesource.com/node_16.x buster main"
-RUN apt-get update && apt-get install -y \
-    nodejs=16.15.1-deb-1nodesource1 \
-    && rm -rf /var/lib/apt/lists/*
+FROM node:16.15.1
 WORKDIR /lune-ts


### PR DESCRIPTION
Installing Node from nodesource through apt is problematic in a way
described in [1] – only the latest versions can be installed easily.

To avoid issues in the future let's use the official image – we can
install any version easily, new releases won't break it.

[1] 827a87ff34e4 ("Fix Node installation in the Dockerfile (#61)")