### PR TITLE
Get rid of the chown hack by downgrading npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,35 @@ RUN add-apt-repository "https://deb.nodesource.com/node_16.x buster main"
 RUN apt-get update && apt-get install -y \
     nodejs=16.15.1-deb-1nodesource1 \
     && rm -rf /var/lib/apt/lists/*
+
+# Why is this needed?
+#
+# In GH Actions the /lune-ts volume is mounted not under root but using a different
+# user (UID 1001).
+#
+# This wouldn't be an issue if npm didn't have a very annoying behavior: if the
+# current user is root (which it is in the container we run) but the current
+# directory is owned by a different user npm run spawns subprocesses with the
+# current directory owner being the process' UID. When that happens anything that
+# tries to access /root (the home directory of the original user we're running
+# as, the home directory of the current user is not modified by npm when spawning
+# processes) will get the EACCES/13 error from the operating system.
+#
+# The aboe *still* wouldn't be an issue: npm 8.5.5 just logs a warning in this case
+# and moves on. Unfortunately npm 8.11.1 which is bundled with Node 16.15.1 just dies and
+# exits with code -13 (negative EACCES/13) without printing anything. -13 gets translated
+# to code 243 somewhere along the way (-13 signed u8 is 243 unsigned, 256 - 13 = 243;
+# I'm not up to speed regarding the range of exit codes, I imagine they're just
+# limited to 8 bits unsigned (Jakub)).
+#
+# npm issues to keep track of:
+#
+# * https://github.com/npm/cli/issues/4996
+# * https://github.com/npm/cli/issues/4838
+# * https://github.com/npm/cli/issues/4769
+#
+# Let's downgrade npm for now. We could also switch to yarn which doesn't have the
+# change-the-user-silently misfeature.
+RUN npm install -g npm@8.5.5
+
 WORKDIR /lune-ts

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -2,38 +2,12 @@ version: "3.9"
 services:
   update_from_remote_schema:
     build: .
-    # The chown call below is a hack to keep this working in GitHub Actions with npm
-    # 8.11.1. Why is this needed?
-    #
-    # In GH Actions the /lune-ts volume is mounted not under root but using a different
-    # user (UID 1001).
-    #
-    # This wouldn't be an issue if npm didn't have a very annoying behavior: if the
-    # current user is root (which it is in the container we run) but the current
-    # directory is owned by a different user npm run spawns subprocesses with the
-    # current directory owner being the process' UID. When that happens anything that
-    # tries to access /root (the home directory of the original user we're running
-    # as, the home directory of the current user is not modified by npm when spawning
-    # processes) will get the EACCES/13 error from the operating system.
-    #
-    # The aboe *still* wouldn't be an issue: npm 8.5.5 just logs a warning in this case
-    # and moves on. Unfortunately npm 8.11.1 which is bundled with Node 16.15.1 just dies and
-    # exits with code -13 (negative EACCES/13) without printing anything. -13 gets translated
-    # to code 243 somewhere along the way (-13 signed u8 is 243 unsigned, 256 - 13 = 243;
-    # I'm not up to speed regarding the range of exit codes, I imagine they're just
-    # limited to 8 bits unsigned (Jakub)).
-    #
-    # npm issues to keep track of:
-    #
-    # * https://github.com/npm/cli/issues/4996
-    # * https://github.com/npm/cli/issues/4838
-    # * https://github.com/npm/cli/issues/4769
-    command: bash -c "chown -R root /lune-ts && cd /lune-ts && make build-from-schema"
+    command: bash -c "cd /lune-ts && make build-from-schema"
     volumes:
       - .:/lune-ts
   build_from_source:
     build: .
     # See the update_from_remote_schema chown comment above for some context.
-    command: bash -c "chown -R root /lune-ts && cd /lune-ts && make build-from-source"
+    command: bash -c "cd /lune-ts && make build-from-source"
     volumes:
       - .:/lune-ts


### PR DESCRIPTION
Seems like chowning in GH Actions breaks the rebuild_schema_change
action which then fails[1] with:

  /usr/bin/git config --local --name-only --get-regexp http.https://github.com/.extraheader ^AUTHORIZATION:
  http.https://github.com/.extraheader
  /usr/bin/git config --local --get-regexp http.https://github.com/.extraheader ^AUTHORIZATION:
  http.https://github.com/.extraheader AUTHORIZATION: basic ***
  /usr/bin/git config --local --unset http.https://github.com/.extraheader ^AUTHORIZATION:
  error: could not lock config file .git/config: Permission denied

It really looks like working directory permission issue so the chown is
a suspect – let's get rid of it and see.

[1] https://github.com/lune-climate/lune-ts/runs/6835801850?check_suite_focus=true