### PR TITLE
Fix environment name for bump workflows

### DIFF
--- a/.github/workflows/bump-version-major.yml
+++ b/.github/workflows/bump-version-major.yml
@@ -11,7 +11,7 @@ jobs:
     name: Bump version (major) and create PR.
     runs-on: ubuntu-latest
     # The environment is used to guarantee that a manual approval is required.
-    environment: bump_version_major
+    environment: bump_version
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -11,7 +11,7 @@ jobs:
     name: Bump version (minor) and create PR.
     runs-on: ubuntu-latest
     # The environment is used to guarantee that a manual approval is required.
-    environment: bump_version_minor
+    environment: bump_version
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/bump-version-patch.yml
+++ b/.github/workflows/bump-version-patch.yml
@@ -11,7 +11,7 @@ jobs:
     name: Bump version (patch) and create PR.
     runs-on: ubuntu-latest
     # The environment is used to guarantee that a manual approval is required.
-    environment: bump_version_patch
+    environment: bump_version
 
     steps:
       - name: Checkout the code


### PR DESCRIPTION
We don't need or want one environment for each. Instead use the same
environment that requires manual approval for all of them.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>