### PR TITLE
Set bash as default interpreter on makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash # Use bash syntax
+SHELL := /bin/bash # Required for the publish ignoring same version error
 
 .PHONY: build-image
 build-image:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash # Use bash syntax
+
 .PHONY: build-image
 build-image:
 	docker compose build


### PR DESCRIPTION
For publishing while ignoring the same version error, we have bash
syntax that was failing due to the interpreter on CI being different.
Simply make sure we use bash. This shouldn't affect other
commands since they're very straightforward.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>