### PR TITLE
Perform publish workflow on change to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - 'package.json'
 
 jobs:
   build:


### PR DESCRIPTION
Instead of only trying to perform the publish workflow when the
`package.json` file changes, this makes it so that any change in master
results in an attempt to publish to NPM.

The initial limitation was to try and minimize the amount of unnecessary
work to be done, since anything besides bumping the version wouldn't
require a publish attempt.
However, by having it in place it becomes impossible to trigger a publish
if a fix to the publish process was made that doesn't affect the
`package.json` file.

This change I believe also goes more in line with the more streamline
approach we want to move towards. We are already relying on NPM to make
sure we don't publish if the version remained the same, so this just
goes all in.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>