### PR TITLE
Fix snake case keys in error responses

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -47,8 +47,15 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        this.client.interceptors.response.use((response) => {
-            return { ...response, data: camelCaseKeys(response.data, { deep: true }) }
+        const camelCaseResponse = (response) => ({
+            ...response,
+            data: camelCaseKeys(response.data, { deep: true }),
+        })
+        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+            // There's a separate, slightly different callback for errors.
+            error.response = camelCaseResponse(error.response)
+            // We need to return a rejected promise for it to work nice with axios.
+            return Promise.reject(error)
         })
     }
 


### PR DESCRIPTION
We forgot that error responses are processed differently from success
responses so we had to modify the camel-case interceptor to handle this.

Previously ApiError.errors contained something like

    {"errors":[{"error_code":"token_invalid","message":"Invalid token."}]}

Now it's

    {"errors":[{"errorCode":"token_invalid","message":"Invalid token."}]}

which matches the type definitions.