### PR TITLE
Disallow unnecessary conditionals

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
     // These are needed for some of the typescript-eslint type-based linting rules like
     // no-unnecessary-condition.
     "tsconfigRootDir": __dirname,
-    "project": ["./tsconfig.json"],
+    "project": ["./tsconfig-esm.json"],
   },
   plugins: ["@typescript-eslint", "simple-import-sort"],
   rules: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,11 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 12,
     sourceType: "module",
+
+    // These are needed for some of the typescript-eslint type-based linting rules like
+    // no-unnecessary-condition.
+    "tsconfigRootDir": __dirname,
+    "project": ["./tsconfig.json"],
   },
   plugins: ["@typescript-eslint", "simple-import-sort"],
   rules: {
@@ -22,6 +27,7 @@ module.exports = {
     ],
     "no-useless-constructor": "off",
     "no-unused-vars": "off",
+    '@typescript-eslint/no-unnecessary-condition': ['error'],
     "@typescript-eslint/no-useless-constructor": ["error"],
     "@typescript-eslint/no-unused-vars": [
       "error",


### PR DESCRIPTION
"X ?? Y", "X?property", "X!" etc. when X can't be null-ish are one of two
things:

1. Unnecessary, thus confusing the developers ("Why are we having
   conditionals where no conditionals are necessary? Are the type
   declarations incorrect?")
2. A sign of the type declarations being incorrect

Either way I believe we need to get rid of all instances of that and
enabling this linting rule will ensure the problem doesn't come back.