### PR TITLE
Fix bump version twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,17 +41,14 @@ build-from-source: install check-linting build
 
 patch-version:
 	npm --no-git-tag-version version patch
-	cd src && npm --no-git-tag-version version patch
 	npm ci
 
 minor-version:
 	npm --no-git-tag-version version minor
-	cd src && npm --no-git-tag-version version minor
 	npm ci
 
 major-version:
 	npm --no-git-tag-version version major
-	cd src && npm --no-git-tag-version version major
 	npm ci
 
 publish:


### PR DESCRIPTION
Due to the unification of package.json, we now don't need to bump the version in two different files. This was making the bump happen twice.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>