### PR TITLE
Upgrade to Lune's openapi-typescript-codegen 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ts-results-es": "^3.4.0"
       },
       "devDependencies": {
-        "@lune-climate/openapi-typescript-codegen": "^0.0.14",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.0",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "eslint": "^7.32.0",
@@ -219,9 +219,9 @@
       "dev": true
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.0.14.tgz",
-      "integrity": "sha512-9XBK1jw6QwZewRyh4YBnxa0pyu1SdmsMdo6PwHeGSI2n5bMvrINCsC+XDUYXPWAxDxvc7eGGFl0Jp+meLLJZWg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.0.tgz",
+      "integrity": "sha512-JHk5l2vioaoTg1rtruVclzz/zY8RzCVQ/34w7tVwEWBb1QF2Dm73M515iWD+M0pK8Wp05tx34O15OvvFxtT19Q==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -3122,9 +3122,9 @@
       "dev": true
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.0.14.tgz",
-      "integrity": "sha512-9XBK1jw6QwZewRyh4YBnxa0pyu1SdmsMdo6PwHeGSI2n5bMvrINCsC+XDUYXPWAxDxvc7eGGFl0Jp+meLLJZWg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.0.tgz",
+      "integrity": "sha512-JHk5l2vioaoTg1rtruVclzz/zY8RzCVQ/34w7tVwEWBb1QF2Dm73M515iWD+M0pK8Wp05tx34O15OvvFxtT19Q==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-results-es": "^3.4.0"
   },
   "devDependencies": {
-    "@lune-climate/openapi-typescript-codegen": "^0.0.14",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.0",
     "typescript": "^4.6.2",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,8 +47,15 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        this.client.interceptors.response.use((response) => {
-            return { ...response, data: camelCaseKeys(response.data, { deep: true }) }
+        const camelCaseResponse = (response) => ({
+            ...response,
+            data: camelCaseKeys(response.data, { deep: true }),
+        })
+        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+            // There's a separate, slightly different callback for errors.
+            error.response = camelCaseResponse(error.response)
+            // We need to return a rejected promise for it to work nice with axios.
+            return Promise.reject(error)
         })
     }
 


### PR DESCRIPTION
We need this to get a fix for snake case keys in error responses[1].

[1] https://github.com/lune-climate/openapi-typescript-codegen/pull/39