### PR TITLE
Update base client generator and regenerate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ts-results-es": "^3.4.0"
       },
       "devDependencies": {
-        "@lune-climate/openapi-typescript-codegen": "^0.1.1",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.2",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "eslint": "^7.32.0",
@@ -219,9 +219,9 @@
       "dev": true
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.1.tgz",
-      "integrity": "sha512-XPw3iJoeZDXKOyRKgO2NbhgzwZgS9DSy+1GvDy1k9NUfQ86DkqdiGIGwOiv/tvdRhb7bLPLKNmlfOrA2/FvUVg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.2.tgz",
+      "integrity": "sha512-mVIminDnl0J6Pfr9eUyfpSgVW3nli6EzvymmdUxjruYHszulLKX0NB+80jWaMGrzHbsxzA0FDng7ylp+lRaE2Q==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -3122,9 +3122,9 @@
       "dev": true
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.1.tgz",
-      "integrity": "sha512-XPw3iJoeZDXKOyRKgO2NbhgzwZgS9DSy+1GvDy1k9NUfQ86DkqdiGIGwOiv/tvdRhb7bLPLKNmlfOrA2/FvUVg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.2.tgz",
+      "integrity": "sha512-mVIminDnl0J6Pfr9eUyfpSgVW3nli6EzvymmdUxjruYHszulLKX0NB+80jWaMGrzHbsxzA0FDng7ylp+lRaE2Q==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-results-es": "^3.4.0"
   },
   "devDependencies": {
-    "@lune-climate/openapi-typescript-codegen": "^0.1.1",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.2",
     "typescript": "^4.6.2",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",

--- a/src/services/OrdersService.ts
+++ b/src/services/OrdersService.ts
@@ -33,7 +33,11 @@ export abstract class OrdersService {
      * @returns OrderByQuantity OK
      */
     public createOrderByMass(
-        data: CreateOrderByQuantityWithBundlePercentage | CreateOrderByQuantityWithBundleMass,
+        data: {
+            createOrderByQuantityRequest:
+                | CreateOrderByQuantityWithBundlePercentage
+                | CreateOrderByQuantityWithBundleMass
+        },
         options?: {
             /**
              * Account Id to be used to perform the API call
@@ -44,7 +48,7 @@ export abstract class OrdersService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass',
-            body: data,
+            body: data?.createOrderByQuantityRequest,
             mediaType: 'application/json',
             errors: {
                 400: `The request is invalid. Parameters may be missing or are invalid`,
@@ -325,7 +329,11 @@ export abstract class OrdersService {
      * @returns OrderQuoteByQuantity OK
      */
     public getOrderQuoteByMass(
-        data: OrderQuoteByQuantityWithBundlePercentage | OrderQuoteByQuantityWithBundleMass,
+        data: {
+            orderQuoteByQuantityRequest:
+                | OrderQuoteByQuantityWithBundlePercentage
+                | OrderQuoteByQuantityWithBundleMass
+        },
         options?: {
             /**
              * Account Id to be used to perform the API call
@@ -336,7 +344,7 @@ export abstract class OrdersService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass/quote',
-            body: data,
+            body: data?.orderQuoteByQuantityRequest,
             mediaType: 'application/json',
             errors: {
                 400: `The request is invalid. Parameters may be missing or are invalid`,


### PR DESCRIPTION
The new base client has fixes to oneOf elements at the root. This makes the build now succeed when auto generated and makes the manual fix previously done obsolete. Regenerate the models.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>