### PR TITLE
Upgrade deprecated dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ts-results-es": "^3.4.0"
       },
       "devDependencies": {
-        "@lune-climate/openapi-typescript-codegen": "^0.1.1",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.2",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "eslint": "^7.32.0",
@@ -219,9 +219,9 @@
       "dev": true
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.1.tgz",
-      "integrity": "sha512-XPw3iJoeZDXKOyRKgO2NbhgzwZgS9DSy+1GvDy1k9NUfQ86DkqdiGIGwOiv/tvdRhb7bLPLKNmlfOrA2/FvUVg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.2.tgz",
+      "integrity": "sha512-mVIminDnl0J6Pfr9eUyfpSgVW3nli6EzvymmdUxjruYHszulLKX0NB+80jWaMGrzHbsxzA0FDng7ylp+lRaE2Q==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -3122,9 +3122,9 @@
       "dev": true
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.1.tgz",
-      "integrity": "sha512-XPw3iJoeZDXKOyRKgO2NbhgzwZgS9DSy+1GvDy1k9NUfQ86DkqdiGIGwOiv/tvdRhb7bLPLKNmlfOrA2/FvUVg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.2.tgz",
+      "integrity": "sha512-mVIminDnl0J6Pfr9eUyfpSgVW3nli6EzvymmdUxjruYHszulLKX0NB+80jWaMGrzHbsxzA0FDng7ylp+lRaE2Q==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": "^0.21.1",
         "camelcase-keys": "^6.2.2",
-        "snakecase-keys": "^4.0.2",
+        "snakecase-keys": "^5.0.0",
         "ts-results-es": "^3.4.0"
       },
       "devDependencies": {
@@ -2603,16 +2603,27 @@
       }
     },
     "node_modules/snakecase-keys": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-4.0.2.tgz",
-      "integrity": "sha512-ZFCo3zZtNN43cy2j4fQDHPxS557Uuzn887FBmDdaSB41D8l/MayuvaSrIlCXGFhZ8sXwrHiNaZiIPpKzi88gog==",
-      "deprecated": "This version contains a breaking change for users depending on unspecified behaviors with repeated capital letters. See https://github.com/bendrucker/snakecase-keys/issues/47. Please upgrade to the identical 5.0.0 release instead.",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
       "dependencies": {
         "map-obj": "^4.1.0",
-        "snake-case": "^3.0.4"
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/snakecase-keys/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {
@@ -4798,12 +4809,20 @@
       }
     },
     "snakecase-keys": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-4.0.2.tgz",
-      "integrity": "sha512-ZFCo3zZtNN43cy2j4fQDHPxS557Uuzn887FBmDdaSB41D8l/MayuvaSrIlCXGFhZ8sXwrHiNaZiIPpKzi88gog==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
       "requires": {
         "map-obj": "^4.1.0",
-        "snake-case": "^3.0.4"
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-results-es": "^3.4.0"
   },
   "devDependencies": {
-    "@lune-climate/openapi-typescript-codegen": "^0.1.1",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.2",
     "typescript": "^4.6.2",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "camelcase-keys": "^6.2.2",
-    "snakecase-keys": "^4.0.2",
+    "snakecase-keys": "^5.0.0",
     "ts-results-es": "^3.4.0"
   },
   "devDependencies": {

--- a/src/services/OrdersService.ts
+++ b/src/services/OrdersService.ts
@@ -33,7 +33,11 @@ export abstract class OrdersService {
      * @returns OrderByQuantity OK
      */
     public createOrderByMass(
-        data: CreateOrderByQuantityWithBundlePercentage | CreateOrderByQuantityWithBundleMass,
+        data: {
+            createOrderByQuantityRequest:
+                | CreateOrderByQuantityWithBundlePercentage
+                | CreateOrderByQuantityWithBundleMass
+        },
         options?: {
             /**
              * Account Id to be used to perform the API call
@@ -44,7 +48,7 @@ export abstract class OrdersService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass',
-            body: data,
+            body: data?.createOrderByQuantityRequest,
             mediaType: 'application/json',
             errors: {
                 400: `The request is invalid. Parameters may be missing or are invalid`,
@@ -325,7 +329,11 @@ export abstract class OrdersService {
      * @returns OrderQuoteByQuantity OK
      */
     public getOrderQuoteByMass(
-        data: OrderQuoteByQuantityWithBundlePercentage | OrderQuoteByQuantityWithBundleMass,
+        data: {
+            orderQuoteByQuantityRequest:
+                | OrderQuoteByQuantityWithBundlePercentage
+                | OrderQuoteByQuantityWithBundleMass
+        },
         options?: {
             /**
              * Account Id to be used to perform the API call
@@ -336,7 +344,7 @@ export abstract class OrdersService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass/quote',
-            body: data,
+            body: data?.orderQuoteByQuantityRequest,
             mediaType: 'application/json',
             errors: {
                 400: `The request is invalid. Parameters may be missing or are invalid`,


### PR DESCRIPTION
We are getting this warning while building:
npm WARN deprecated snakecase-keys@4.0.2: This version contains a breaking change for users depending on unspecified behaviors with repeated capital letters. See https://github.com/bendrucker/snakecase-keys/issues/47. Please upgrade to the identical 5.0.0 release instead.

This updates the library and regenerates the models to make sure nothing has changed.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>