### PR TITLE
Update ts-results-es to v3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^0.21.1",
         "camelcase-keys": "^6.2.2",
         "snakecase-keys": "^5.0.0",
-        "ts-results-es": "^3.4.0"
+        "ts-results-es": "^3.5.0"
       },
       "devDependencies": {
         "@lune-climate/openapi-typescript-codegen": "^0.1.2",
@@ -2795,9 +2795,9 @@
       }
     },
     "node_modules/ts-results-es": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ts-results-es/-/ts-results-es-3.4.0.tgz",
-      "integrity": "sha512-mD6QQg24ihnzxpkR4fuXa+xRP/cTPnRLT6hcI0VfUCMur1joBq7fJnZ3BsgHJ4qswWDS/HdyoS3PS2BnCADy1Q=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ts-results-es/-/ts-results-es-3.5.0.tgz",
+      "integrity": "sha512-W7Vtg9u7QsutEfDbLEJNDlDrYGK7spxab6Je+K9+tjI/ixCM1ouniQmHJX0mZUok5WsWiCGxQy6lIrI//nBzTg=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -4953,9 +4953,9 @@
       }
     },
     "ts-results-es": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ts-results-es/-/ts-results-es-3.4.0.tgz",
-      "integrity": "sha512-mD6QQg24ihnzxpkR4fuXa+xRP/cTPnRLT6hcI0VfUCMur1joBq7fJnZ3BsgHJ4qswWDS/HdyoS3PS2BnCADy1Q=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ts-results-es/-/ts-results-es-3.5.0.tgz",
+      "integrity": "sha512-W7Vtg9u7QsutEfDbLEJNDlDrYGK7spxab6Je+K9+tjI/ixCM1ouniQmHJX0mZUok5WsWiCGxQy6lIrI//nBzTg=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "axios": "^0.21.1",
     "camelcase-keys": "^6.2.2",
     "snakecase-keys": "^5.0.0",
-    "ts-results-es": "^3.4.0"
+    "ts-results-es": "^3.5.0"
   },
   "devDependencies": {
     "@lune-climate/openapi-typescript-codegen": "^0.1.2",


### PR DESCRIPTION
Version 3.5.0 includes support for `expectErr`, `mapOr`, `mapOrElse`.
