### PR TITLE
Prevent clients from importing the package internals

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": {
       "import": "./esm/client.js",
       "require": "./cjs/client.js"
-    }
+    },
+    "./*": null
   },
   "keywords": [
     "Lune"


### PR DESCRIPTION
Breaking change.

Some clients are mistakenly importing from the package's internal modules, for example the CSV shipping tool[1]:

    lune-shipping-csv-tool% rg lune-climate/lune/
    src/index.ts
    9:import { ApiError } from '@lune-climate/lune/cjs/core/ApiError'

    src/types.ts
    1:import { MultiLegShippingEmissionEstimate } from '@lune-climate/lune/esm/models/MultiLegShippingEmissionEstimate'
    2:import { Shipment } from '@lune-climate/lune/esm/models/Shipment'
    3:import { ShippingCountryCode } from '@lune-climate/lune/esm/models/ShippingCountryCode'
    4:import { ShippingMethod } from '@lune-climate/lune/esm/models/ShippingMethod'
    5:import { ShippingRoute } from '@lune-climate/lune/esm/models/ShippingRoute'

    src/utils.ts
    6:import { MultiLegShippingEmissionEstimate } from '@lune-climate/lune/esm/models/MultiLegShippingEmissionEstimate'

The /models/ imports can be changed to import from @lune-climate/lune directly and it'll just work. The ApiError import will actually be impossible with this change but I'll be removing it from lune-shipping-csv-tool anyway. If it turns out it's needed for something we'll explicitly add it to the package's main entry point.

I found this null trick at [2].

[1] https://github.com/lune-climate/lune-shipping-csv-tool/tree/71d05d2617a7af753409101e68556ea1ee1dd8d8 [2] https://nodejs.org/api/packages.html#packages_package_entry_points