### PR TITLE
Update openapi-typescript-codegen to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ts-results-es": "^3.4.0"
       },
       "devDependencies": {
-        "@lune-climate/openapi-typescript-codegen": "^0.1.4",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.5",
         "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
@@ -220,9 +220,9 @@
       "dev": true
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.4.tgz",
-      "integrity": "sha512-acLYp8gBxqgDdtWhg8ziptS6aMlB9KnUwEAxccNrLyw/HaOfXh2cGnlUvbCCUSH2H9t4tBwfam6TO0/UpiksFA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.5.tgz",
+      "integrity": "sha512-VpE7yJQ+gNxZzqkqi+2GA+XXZ1rrbIdkZN0GvTzernzlaD91B52WiZRPX8OUdU8M09YOtb6K5e53CEopg4FPlA==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -3212,9 +3212,9 @@
       "dev": true
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.4.tgz",
-      "integrity": "sha512-acLYp8gBxqgDdtWhg8ziptS6aMlB9KnUwEAxccNrLyw/HaOfXh2cGnlUvbCCUSH2H9t4tBwfam6TO0/UpiksFA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.5.tgz",
+      "integrity": "sha512-VpE7yJQ+gNxZzqkqi+2GA+XXZ1rrbIdkZN0GvTzernzlaD91B52WiZRPX8OUdU8M09YOtb6K5e53CEopg4FPlA==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-results-es": "^3.4.0"
   },
   "devDependencies": {
-    "@lune-climate/openapi-typescript-codegen": "^0.1.4",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.5",
     "typescript": "^4.6.2",
     "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^5.15.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig'
@@ -47,13 +47,24 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response) => ({
+        const camelCaseResponse = (response: AxiosResponse<unknown, unknown>) => ({
             ...response,
-            data: camelCaseKeys(response.data, { deep: true }),
+            // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+            // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+            //
+            // Instead of writing a bunch of type-detecting conditional code to satisfy the
+            // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+            // value do we actually deal with here but the library will handle it.
+            data: camelCaseKeys(response.data as any, { deep: true }),
         })
-        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+        this.client.interceptors.response.use(camelCaseResponse, (error: unknown) => {
             // There's a separate, slightly different callback for errors.
-            error.response = camelCaseResponse(error.response)
+            if (!isAxiosError(error)) {
+                throw error
+            }
+            if (error.response) {
+                error.response = camelCaseResponse(error.response)
+            }
             // We need to return a rejected promise for it to work nice with axios.
             return Promise.reject(error)
         })


### PR DESCRIPTION
This version[1] contains two changes:

* A bug fix for handling connection errors[2]
* A type annotation improvement[3]

The former is really important as the bug was causing us to handle (and report) errors incorrectly.

[1] https://github.com/lune-climate/openapi-typescript-codegen/releases/tag/v0.1.5
[2] https://github.com/lune-climate/openapi-typescript-codegen/pull/51
[3] https://github.com/lune-climate/openapi-typescript-codegen/pull/52