### PR TITLE
Disallow values being implicitly "any"

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -12,7 +12,6 @@
     "strict": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noImplicitAny": false,
     "baseUrl": "./",
     "target": "ES2019",
     "esModuleInterop": true,


### PR DESCRIPTION
We had a pretty bad bug[1] that was allowed to compile only because we had noImplicitAny disabled.

It's been disabled for historical reasons, we like this check and want it active.

[1] https://github.com/lune-climate/lune-ts/pull/260