### PR TITLE
[LUN-2686] Expose the connection error details

### DIFF
--- a/src/core/ApiError.ts
+++ b/src/core/ApiError.ts
@@ -47,7 +47,7 @@ export function constructApiError(error: AxiosError, options: ApiRequestOptions)
         // http.ClientRequest in node.js
         return {
             description:
-                'Something went wrong communicating with Lune. Please contact support if this happens again.',
+                `Something went wrong communicating with Lune: ${error.message}. Please contact support if this happens again.`,
         }
     } else {
         throw new Error(


### PR DESCRIPTION
It's useful to know whether something failed because of a DNS error, a failure to connect to a host or some other reason.

Exposing this information in a human-centric way other than targetting programmatic consumption for now, if there's demand for the latter we can think about improving it.

Resolves: https://linear.app/lune/issue/LUN-2686/the-ts-client-hides-details-about-the-connection-errors