### PR TITLE
Remove an invalid type declaration location

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Lune Typescript Client",
   "main": "cjs/client.js",
   "module": "esm/client.js",
-  "types": "esm/client.d.ts",
   "exports": {
     ".": {
       "import": "./esm/client.js",


### PR DESCRIPTION
We shouldn't declare one type declaration file for both ESM and CJS – the type declaration used depends on whether an import is a CJS or ESM import[1].

This doesn't look like it's been causing issues so far, let's just fix it proactively.

[1] https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/4786ef2571de5772cece4c671847456b9746437e/docs/problems/FalseESM.md#common-causes