### PR TITLE
Restrict the version of camelcase-keys to CJS-compatible ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",
-        "camelcase-keys": "^6.2.2",
+        "camelcase-keys": "<8.0.0",
         "snakecase-keys": "^5.0.0",
         "ts-results-es": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
-    "camelcase-keys": "^6.2.2",
+    "camelcase-keys": "<8.0.0",
     "snakecase-keys": "^5.0.0",
     "ts-results-es": "^4.0.0"
   },


### PR DESCRIPTION
camelcase-keys is ESM-only starting with 8.0.0[1] and we don't quite want to make lune-ts ESM-only just yet.

[1] https://github.com/sindresorhus/camelcase-keys/releases/tag/v8.0.0