### PR TITLE
Remove an unnecessary property name in an object literal

### DIFF
--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -201,7 +201,7 @@ export const request = async <T>(
     return client({
         baseURL: url,
         method: options.method,
-        headers: headers,
+        headers,
         params: formData,
         data: body,
     })


### PR DESCRIPTION
A prerequisite for [1] which will introduce ESLint configuration prohibiting redundant labels like this.

[1] https://linear.app/lune/issue/LUN-2856/centralize-our-eslint-configuration