### PR TITLE
Improve the way version-bumping PRs are created

### DIFF
--- a/.github/workflows/bump-version-major.yml
+++ b/.github/workflows/bump-version-major.yml
@@ -2,16 +2,12 @@ name: Create PR with bump major version
 
 # Perform workflow based on human approval
 on:
-  push:
-    branches:
-      - master
+  - workflow_dispatch
 
 jobs:
   build:
     name: Bump version (major) and create PR.
     runs-on: ubuntu-latest
-    # The environment is used to guarantee that a manual approval is required.
-    environment: bump_version
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -2,16 +2,12 @@ name: Create PR with bump minor version
 
 # Perform workflow based on human approval
 on:
-  push:
-    branches:
-      - master
+  - workflow_dispatch
 
 jobs:
   build:
     name: Bump version (minor) and create PR.
     runs-on: ubuntu-latest
-    # The environment is used to guarantee that a manual approval is required.
-    environment: bump_version
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/bump-version-patch.yml
+++ b/.github/workflows/bump-version-patch.yml
@@ -2,16 +2,12 @@ name: Create PR with bump patch version
 
 # Perform workflow based on human approval
 on:
-  push:
-    branches:
-      - master
+  - workflow_dispatch
 
 jobs:
   build:
     name: Bump version (patch) and create PR.
     runs-on: ubuntu-latest
-    # The environment is used to guarantee that a manual approval is required.
-    environment: bump_version
 
     steps:
       - name: Checkout the code

--- a/README.md
+++ b/README.md
@@ -102,7 +102,14 @@ An API change was released to Production. You want to start using it via the lun
 1. Backend repo: Make sure the change is actually live in the API 
 2. Docs repo: Make sure the change is published in the docs. _theoretically_ this should happen automatically. Due to some vague race condition, the **Update API reference** job might run without picking up the latest API version. Go check https://docs.lune.co/ and make sure you can see your change. If your change is NOT there - re-trigger the process by going to one of the runs of **Update API reference** job (like https://github.com/lune-climate/lune-docs/actions/runs/5963925137) and clicking the "Re-run all jobs" button.
 3. ts-lune repo: 2. should trigger **rebuild_schema_change** workflow https://github.com/lune-climate/lune-ts/actions/workflows/rebuild-schema.yml which in turn opens a PR introducing the new API stuff to the ts-client. Go approve and merge that PR.
-4. ts-lune repo: Kick off the **Create PR with bump patch version** workflow (there's also a minor/major version workflow) by going here https://github.com/lune-climate/lune-ts/actions/workflows/bump-version-patch.yml, manually clicking into the latest workflow, clicking **Cancel workflow**, then **Re-run jobs**, then **Re-run all jobs**. Wait for job to finish.
+4. ts-lune repo: Kick off a version bump PR. Pick one:
+   * Patch version bump https://github.com/lune-climate/lune-ts/actions/workflows/bump-version-patch.yml
+   * Minor version bump https://github.com/lune-climate/lune-ts/actions/workflows/bump-version-minor.yml
+   * Major version bump https://github.com/lune-climate/lune-ts/actions/workflows/bump-version-major.yml
+   
+   and use the "Run workflow" button.
+   
+   Wait for job to finish.
 5. ts-lune repo: 4. should create a PR that bumps the ts-client to a new version. Approve and merge this.
 6. npm registry: Go to and wait until you can see that the new version was published https://www.npmjs.com/package/@lune-climate/lune (this should have happened automatically after merging new version number to MASTER as seen in step 5. but seems slow - give it a min)
 7. Bump the version of ts-client in your local repo to match the newly published npm version, run yarn/npm to install it and start using it


### PR DESCRIPTION
Previously we had workflows triggered on all master branch commits and requiring manual approvals through the settings of the bump_version environment[1].

That resulted in all commits generating three unnecessary workflow runs in [2], [3] and [4] with the associated pending deployment notifications and then, after a while (30 days), notifications about deployments timing out.

Let's try a different mechanism when nothing happens until someone goes and manually triggers a workflow – this should reduce the noise substantially.

[1] https://github.com/lune-climate/lune-ts/settings/environments
[2] https://github.com/lune-climate/lune-ts/actions/workflows/bump-version-major.yml
[3] https://github.com/lune-climate/lune-ts/actions/workflows/bump-version-minor.yml
[4] https://github.com/lune-climate/lune-ts/actions/workflows/bump-version-patch.yml