### PR TITLE
Upgrade openapi-typescript-codegen to v0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-        "@lune-climate/openapi-typescript-codegen": "^0.1.8",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.9",
         "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.8.tgz",
-      "integrity": "sha512-T1LStddrL8KqwDaCzaetyN86VpCCrOrfPdo+aNp9GjJiEREIoE1RSlxt4DjaIlqgVoHzouArqclO93PU6y1ONg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.9.tgz",
+      "integrity": "sha512-MJ5cA9qReMkwbIw65Ai+zloHRZahuu+DHvvWby3iUiP5M0ATCAEvQUhPnO5n1Pe7nBcnnh/mX82Eh9/4AlrORw==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -3391,9 +3391,9 @@
       }
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.8.tgz",
-      "integrity": "sha512-T1LStddrL8KqwDaCzaetyN86VpCCrOrfPdo+aNp9GjJiEREIoE1RSlxt4DjaIlqgVoHzouArqclO93PU6y1ONg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.9.tgz",
+      "integrity": "sha512-MJ5cA9qReMkwbIw65Ai+zloHRZahuu+DHvvWby3iUiP5M0ATCAEvQUhPnO5n1Pe7nBcnnh/mX82Eh9/4AlrORw==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-    "@lune-climate/openapi-typescript-codegen": "^0.1.8",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.9",
     "typescript": "^5.1.6",
     "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^7.0.1",


### PR DESCRIPTION
This version contains fixes to when the `data` parameter is considered optional or not.