### PR TITLE
Update API schema

### DIFF
--- a/src/services/AccountsService.ts
+++ b/src/services/AccountsService.ts
@@ -17,6 +17,7 @@ import type { UploadLogoResponse } from '../models/UploadLogoResponse.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -35,7 +36,7 @@ export abstract class AccountsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<Account, ApiError>> {
+    }): Promise<Result<SuccessResponse<Account>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts/me',
@@ -83,7 +84,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<AccountPair, ApiError>> {
+    ): Promise<Result<SuccessResponse<AccountPair>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts',
@@ -139,7 +140,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<PaginatedAccounts, ApiError>> {
+    ): Promise<Result<SuccessResponse<PaginatedAccounts>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts',
@@ -194,7 +195,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<Account, ApiError>> {
+    ): Promise<Result<SuccessResponse<Account>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/accounts/{id}',
@@ -258,7 +259,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<Account, ApiError>> {
+    ): Promise<Result<SuccessResponse<Account>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/accounts/{id}',
@@ -302,7 +303,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<UploadLogoResponse, ApiError>> {
+    ): Promise<Result<SuccessResponse<UploadLogoResponse>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts/{id}/logo',

--- a/src/services/AnalyticsService.ts
+++ b/src/services/AnalyticsService.ts
@@ -17,6 +17,7 @@ import type { EmissionCalculationMetrics } from '../models/EmissionCalculationMe
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -50,7 +51,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<CumulativeBundleAnalytics, ApiError>> {
+    ): Promise<Result<SuccessResponse<CumulativeBundleAnalytics>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/cumulative-per-bundle',
@@ -91,7 +92,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<AnalyticsMetrics, ApiError>> {
+    ): Promise<Result<SuccessResponse<AnalyticsMetrics>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/metrics',
@@ -132,7 +133,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<AggregatedAnalyticsByProperty, ApiError>> {
+    ): Promise<Result<SuccessResponse<AggregatedAnalyticsByProperty>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/aggregated-by-property',
@@ -183,7 +184,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<EmissionCalculationMetrics, ApiError>> {
+    ): Promise<Result<SuccessResponse<EmissionCalculationMetrics>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/emission-calculations',
@@ -233,7 +234,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<AnalyticsShippingEstimates, ApiError>> {
+    ): Promise<Result<SuccessResponse<AnalyticsShippingEstimates>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/shipping/public/{account_id}',

--- a/src/services/BundlePortfoliosService.ts
+++ b/src/services/BundlePortfoliosService.ts
@@ -13,6 +13,7 @@ import type { BundlePortfolio } from '../models/BundlePortfolio.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -31,7 +32,7 @@ export abstract class BundlePortfoliosService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<Array<BundlePortfolio>, ApiError>> {
+    }): Promise<Result<SuccessResponse<Array<BundlePortfolio>>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundle-portfolios',
@@ -58,7 +59,7 @@ export abstract class BundlePortfoliosService {
              */
             accountId?: string
         },
-    ): Promise<Result<BundlePortfolio, ApiError>> {
+    ): Promise<Result<SuccessResponse<BundlePortfolio>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/bundle-portfolios',

--- a/src/services/BundleSelectionsService.ts
+++ b/src/services/BundleSelectionsService.ts
@@ -14,6 +14,7 @@ import type { BundleSelection } from '../models/BundleSelection.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -32,7 +33,7 @@ export abstract class BundleSelectionsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<BundleSelection, ApiError>> {
+    }): Promise<Result<SuccessResponse<BundleSelection>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundle-selections',
@@ -59,7 +60,7 @@ export abstract class BundleSelectionsService {
              */
             accountId?: string
         },
-    ): Promise<Result<BundleSelection, ApiError>> {
+    ): Promise<Result<SuccessResponse<BundleSelection>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/bundle-selections',

--- a/src/services/BundlesService.ts
+++ b/src/services/BundlesService.ts
@@ -14,6 +14,7 @@ import type { PaginatedBundles } from '../models/PaginatedBundles.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -55,7 +56,7 @@ export abstract class BundlesService {
              */
             accountId?: string
         },
-    ): Promise<Result<PaginatedBundles, ApiError>> {
+    ): Promise<Result<SuccessResponse<PaginatedBundles>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundles',
@@ -86,7 +87,7 @@ export abstract class BundlesService {
              */
             accountId?: string
         },
-    ): Promise<Result<Bundle, ApiError>> {
+    ): Promise<Result<SuccessResponse<Bundle>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundles/{id}',

--- a/src/services/ClientAccountsService.ts
+++ b/src/services/ClientAccountsService.ts
@@ -16,6 +16,7 @@ import type { UploadLogoResponse } from '../models/UploadLogoResponse.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -34,7 +35,7 @@ export abstract class ClientAccountsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<ClientAccount, ApiError>> {
+    }): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts/client/me',
@@ -80,7 +81,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<ClientAccount, ApiError>> {
+    ): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts/client',
@@ -138,7 +139,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<PaginatedClientAccounts, ApiError>> {
+    ): Promise<Result<SuccessResponse<PaginatedClientAccounts>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts/client',
@@ -191,7 +192,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<ClientAccount, ApiError>> {
+    ): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/accounts/client/{id}',
@@ -253,7 +254,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<ClientAccount, ApiError>> {
+    ): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/accounts/client/{id}',
@@ -297,7 +298,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<UploadLogoResponse, ApiError>> {
+    ): Promise<Result<SuccessResponse<UploadLogoResponse>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts/client/{id}/logo',

--- a/src/services/EmissionEstimatesService.ts
+++ b/src/services/EmissionEstimatesService.ts
@@ -49,6 +49,7 @@ import type { TransactionEstimateRequest } from '../models/TransactionEstimateRe
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -90,7 +91,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<ElectricityEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<ElectricityEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/electricity',
@@ -130,7 +131,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<ElectricityEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<ElectricityEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/electricity/{id}',
@@ -182,7 +183,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<ElectricityEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<ElectricityEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/electricity/{id}',
@@ -246,7 +247,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<FlightEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<FlightEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/flight',
@@ -310,7 +311,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<PassengerTransportationEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<PassengerTransportationEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/passenger-transportation',
@@ -397,7 +398,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<PaginatedAnyShippingEmissionEstimates, ApiError>> {
+    ): Promise<Result<SuccessResponse<PaginatedAnyShippingEmissionEstimates>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/shipping/all',
@@ -470,7 +471,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SingleShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/shipping',
@@ -515,7 +516,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SingleShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/shipping/{id}',
@@ -588,7 +589,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SingleShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/shipping/{id}',
@@ -662,7 +663,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SingleShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/shipping/{id}/annotations',
@@ -738,7 +739,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<MultiLegShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/shipping/multi-leg',
@@ -793,7 +794,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<MultiLegShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/shipping/multi-leg/{id}',
@@ -868,7 +869,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<MultiLegShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/shipping/multi-leg/{id}',
@@ -952,7 +953,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<MultiLegShippingEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/shipping/multi-leg/{id}/annotations',
@@ -1017,7 +1018,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<TransactionEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/transactions',
@@ -1067,7 +1068,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<BatchTransactionEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<BatchTransactionEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/transactions/batch',
@@ -1102,7 +1103,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<TransactionEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/transactions/by-idempotency-key/{idempotency_key}',
@@ -1151,7 +1152,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<TransactionEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/transactions/{id}/annotations',
@@ -1190,7 +1191,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<TransactionEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/transactions/{id}',
@@ -1252,7 +1253,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<TransactionEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/transactions/{id}',
@@ -1402,7 +1403,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<CompanyEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<CompanyEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/company',
@@ -1463,7 +1464,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<CompanyEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<CompanyEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/company/{id}',
@@ -1593,7 +1594,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<CompanyEmissionEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<CompanyEmissionEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/company/{id}',
@@ -1675,7 +1676,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<EmissionFactorEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<EmissionFactorEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/emission-factor',

--- a/src/services/EmissionFactorsService.ts
+++ b/src/services/EmissionFactorsService.ts
@@ -16,6 +16,7 @@ import type { PaginatedEmissionFactors } from '../models/PaginatedEmissionFactor
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -84,7 +85,7 @@ export abstract class EmissionFactorsService {
              */
             accountId?: string
         },
-    ): Promise<Result<PaginatedEmissionFactors, ApiError>> {
+    ): Promise<Result<SuccessResponse<PaginatedEmissionFactors>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/emission-factors',
@@ -117,7 +118,7 @@ export abstract class EmissionFactorsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<EmissionFactorRegions, ApiError>> {
+    }): Promise<Result<SuccessResponse<EmissionFactorRegions>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/emission-factors/regions',

--- a/src/services/OrdersService.ts
+++ b/src/services/OrdersService.ts
@@ -26,6 +26,7 @@ import type { QuantityTrunc } from '../models/QuantityTrunc.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -52,7 +53,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<OrderByQuantity, ApiError>> {
+    ): Promise<Result<SuccessResponse<OrderByQuantity>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass',
@@ -108,7 +109,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<OrderByValue, ApiError>> {
+    ): Promise<Result<SuccessResponse<OrderByValue>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-value',
@@ -162,7 +163,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<OrderByEstimate, ApiError>> {
+    ): Promise<Result<SuccessResponse<OrderByEstimate>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-estimate',
@@ -222,7 +223,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<PaginatedOrders, ApiError>> {
+    ): Promise<Result<SuccessResponse<PaginatedOrders>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders',
@@ -253,7 +254,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<Order, ApiError>> {
+    ): Promise<Result<SuccessResponse<Order>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders/{id}',
@@ -281,7 +282,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<Blob, ApiError>> {
+    ): Promise<Result<SuccessResponse<Blob>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders/{id}/certificate',
@@ -312,7 +313,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<Order, ApiError>> {
+    ): Promise<Result<SuccessResponse<Order>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders/by-idempotency-key/{idempotency_key}',
@@ -348,7 +349,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<OrderQuoteByQuantity, ApiError>> {
+    ): Promise<Result<SuccessResponse<OrderQuoteByQuantity>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass/quote',
@@ -393,7 +394,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<OrderQuoteByValue, ApiError>> {
+    ): Promise<Result<SuccessResponse<OrderQuoteByValue>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-value/quote',

--- a/src/services/PaymentsService.ts
+++ b/src/services/PaymentsService.ts
@@ -13,6 +13,7 @@ import type { Payment } from '../models/Payment.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -39,7 +40,7 @@ export abstract class PaymentsService {
              */
             accountId?: string
         },
-    ): Promise<Result<Payment, ApiError>> {
+    ): Promise<Result<SuccessResponse<Payment>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/payments/by-temporary-id/{temporary_id}',

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -15,6 +15,7 @@ import type { ProjectPerimeter } from '../models/ProjectPerimeter.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -56,7 +57,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<PaginatedProjects, ApiError>> {
+    ): Promise<Result<SuccessResponse<PaginatedProjects>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects',
@@ -87,7 +88,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<Project, ApiError>> {
+    ): Promise<Result<SuccessResponse<Project>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects/{id}',
@@ -115,7 +116,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<ProjectPerimeter, ApiError>> {
+    ): Promise<Result<SuccessResponse<ProjectPerimeter>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects/{id}/perimeter',
@@ -143,7 +144,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<Project, ApiError>> {
+    ): Promise<Result<SuccessResponse<Project>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects/by-slug/{slug}',

--- a/src/services/SustainabilityPageService.ts
+++ b/src/services/SustainabilityPageService.ts
@@ -22,6 +22,7 @@ import type { SustainabilityPageTitle } from '../models/SustainabilityPageTitle.
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -52,7 +53,7 @@ export abstract class SustainabilityPageService {
              */
             accountId?: string
         },
-    ): Promise<Result<SustainabilityPage, ApiError>> {
+    ): Promise<Result<SuccessResponse<SustainabilityPage>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/sustainability-pages',
@@ -98,7 +99,7 @@ export abstract class SustainabilityPageService {
              */
             accountId?: string
         },
-    ): Promise<Result<SustainabilityPage, ApiError>> {
+    ): Promise<Result<SuccessResponse<SustainabilityPage>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/sustainability-pages',
@@ -133,7 +134,7 @@ export abstract class SustainabilityPageService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<SustainabilityPage, ApiError>> {
+    }): Promise<Result<SuccessResponse<SustainabilityPage>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/sustainability-pages/current-account',
@@ -163,7 +164,7 @@ export abstract class SustainabilityPageService {
              */
             accountId?: string
         },
-    ): Promise<Result<PublicSustainabilityPage, ApiError>> {
+    ): Promise<Result<SuccessResponse<PublicSustainabilityPage>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/sustainability-pages/public/{type}/{slug}',

--- a/src/services/WebhookRequestService.ts
+++ b/src/services/WebhookRequestService.ts
@@ -13,6 +13,7 @@ import type { WebhookEvent } from '../models/WebhookEvent.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -42,7 +43,7 @@ export abstract class WebhookRequestService {
              */
             accountId?: string
         },
-    ): Promise<Result<any, ApiError>> {
+    ): Promise<Result<SuccessResponse<any>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/WebhookRequest',

--- a/src/services/WebhooksService.ts
+++ b/src/services/WebhooksService.ts
@@ -15,6 +15,7 @@ import type { WebhookFullSecret } from '../models/WebhookFullSecret.js'
 
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
 import { Result } from 'ts-results-es'
@@ -43,7 +44,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<Array<Webhook>, ApiError>> {
+    ): Promise<Result<SuccessResponse<Array<Webhook>>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/webhooks',
@@ -80,7 +81,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<WebhookFullSecret, ApiError>> {
+    ): Promise<Result<SuccessResponse<WebhookFullSecret>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/webhooks',
@@ -113,7 +114,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<Webhook, ApiError>> {
+    ): Promise<Result<SuccessResponse<Webhook>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/webhooks/{id}',
@@ -160,7 +161,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<Webhook, ApiError>> {
+    ): Promise<Result<SuccessResponse<Webhook>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/webhooks/{id}',
@@ -197,7 +198,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<void, ApiError>> {
+    ): Promise<Result<SuccessResponse<void>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/webhooks/{id}',
@@ -229,7 +230,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<WebhookFullSecret, ApiError>> {
+    ): Promise<Result<SuccessResponse<WebhookFullSecret>, ApiError>> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/webhooks/{id}/rotate-secret',


### PR DESCRIPTION
This picks up the `SuccessResponse` type.
I should have done this before #607 : compatibility by accident!