### PR TITLE
Bump version (major)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lune-climate/lune",
-  "version": "2.17.11",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lune-climate/lune",
-      "version": "2.17.11",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lune-climate/lune",
-  "version": "2.17.11",
+  "version": "3.0.0",
   "description": "Lune Typescript Client",
   "main": "cjs/client.js",
   "module": "esm/client.js",


### PR DESCRIPTION
 Breaking changes:
* Services' functions now return `SuccessResponse<T>`. SuccessResponse<T> has the following backward-incompatible shape `T | { notAnObject: T}` 