### PR TITLE
Fix client.ts file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Build schema from source
-        run: docker-compose -f docker-compose-ci.yml run build_from_source
+        run: docker-compose -f docker-compose-ci.yml run update_from_remote_schema

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-        "@lune-climate/openapi-typescript-codegen": "^0.1.11",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.12",
         "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.11.tgz",
-      "integrity": "sha512-dDi4hikW7R04wqplJuuzZjQoqteRgDIarUPBUPfAVN9As+GlXuxHsNNADlb+R35hlzxtomlQqzvUn2EgkiDq0w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.12.tgz",
+      "integrity": "sha512-03mMa3J3p9DtbCl7rjG7sLHSl8Fu2d0vd7RVF2CTTN/9Kh9/RERImJ7xpn3tb7VWOMFq0zPG2Byya0YidcUptg==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -440,23 +440,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.14.1.tgz",
-      "integrity": "sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.14.1",
-        "@typescript-eslint/visitor-keys": "7.14.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.15.0.tgz",
@@ -552,71 +535,6 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.14.1.tgz",
-      "integrity": "sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz",
-      "integrity": "sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.14.1",
-        "@typescript-eslint/visitor-keys": "7.14.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
@@ -750,23 +668,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz",
-      "integrity": "sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.14.1",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -3721,9 +3622,9 @@
       }
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.11.tgz",
-      "integrity": "sha512-dDi4hikW7R04wqplJuuzZjQoqteRgDIarUPBUPfAVN9As+GlXuxHsNNADlb+R35hlzxtomlQqzvUn2EgkiDq0w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.12.tgz",
+      "integrity": "sha512-03mMa3J3p9DtbCl7rjG7sLHSl8Fu2d0vd7RVF2CTTN/9Kh9/RERImJ7xpn3tb7VWOMFq0zPG2Byya0YidcUptg==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -3899,16 +3800,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.14.1.tgz",
-      "integrity": "sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "7.14.1",
-        "@typescript-eslint/visitor-keys": "7.14.1"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.15.0.tgz",
@@ -3953,48 +3844,6 @@
             "eslint-visitor-keys": "^3.4.3"
           }
         },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.14.1.tgz",
-      "integrity": "sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz",
-      "integrity": "sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "7.14.1",
-        "@typescript-eslint/visitor-keys": "7.14.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -4087,16 +3936,6 @@
             "brace-expansion": "^2.0.1"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz",
-      "integrity": "sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "7.14.1",
-        "eslint-visitor-keys": "^3.4.3"
       }
     },
     "@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-    "@lune-climate/openapi-typescript-codegen": "^0.1.11",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.12",
     "typescript": "^5.1.6",
     "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^7.0.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,12 @@
-import axios, { AxiosError, AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
+import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig.js'
-import { Meta, Method, Methods } from './core/SuccessResponse.js'
+import {
+    ExtendedAxiosError,
+    ExtendedAxiosResponse,
+    extractRequestFromResponseInterceptor,
+} from './core/SuccessResponse.js'
 import { AccountsService } from './services/AccountsService.js'
 import { AnalyticsService } from './services/AnalyticsService.js'
 import { BundlePortfoliosService } from './services/BundlePortfoliosService.js'
@@ -28,39 +32,6 @@ function applyMixins(derivedCtor: any, constructors: any[]) {
             )
         })
     })
-}
-
-export interface ExtendedAxiosResponse<T = any> extends AxiosResponse<T> {
-    _meta: Meta<T>
-}
-
-interface ExtendedAxiosError<T = any> extends AxiosError<T> {
-    response?: ExtendedAxiosResponse<T>
-}
-
-function extractRequestFromResponseInterceptor(response: AxiosResponse): {
-    request: object | null
-    method: Method
-    url: string
-    requestHeaders: { contentType: string | null }
-} {
-    const req = response.config
-    const data = req.data
-
-    if (!Methods.includes((req.method ?? '').toLowerCase())) {
-        throw new Error(`Unexpected method: ${req.method}`)
-    }
-
-    return {
-        method: req.method!,
-        url: req.baseURL!,
-        request: !data ? null : typeof data === 'string' ? JSON.parse(data) : data,
-        requestHeaders: {
-            contentType: req.headers['Content-Type']
-                ? (req.headers['Content-Type'] as string)
-                : null,
-        },
-    }
 }
 
 export class LuneClient {

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -2,11 +2,10 @@ import { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import snakeCaseKeys from 'snakecase-keys'
 import { Err, Ok, Result } from 'ts-results-es'
 
-import { ExtendedAxiosResponse } from '../client.js'
 import { ApiError, constructApiError } from './ApiError.js'
 import type { ApiRequestOptions } from './ApiRequestOptions.js'
 import type { ClientConfig, Headers } from './ClientConfig.js'
-import { asSuccessResponse, SuccessResponse } from './SuccessResponse.js'
+import { asSuccessResponse, ExtendedAxiosResponse, SuccessResponse } from './SuccessResponse.js'
 
 const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
     return value !== undefined && value !== null

--- a/src/models/CurrencyCode.ts
+++ b/src/models/CurrencyCode.ts
@@ -33,4 +33,5 @@ export enum CurrencyCode {
     HUF = 'HUF',
     ISK = 'ISK',
     CZK = 'CZK',
+    CAD = 'CAD',
 }


### PR DESCRIPTION
`client.ts` is autogenerated.

Fixing `clients.ts` requires `@lune-climate/openapi-typescript-codegen` v0.1.12.

The file included manual changes (#607) that were overwritten by the
master build.

The PR build would not overwrite change, hence previous PR builds were
passing.

This change reverts manual changes and ensures the PR build also
regenerates `client.ts`.
