### PR TITLE
Fix running Docker Compose on most recent systems

### DIFF
--- a/.github/workflows/bump-version-major.yml
+++ b/.github/workflows/bump-version-major.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Bump version (major)
-        run: docker-compose -f docker-compose-ci.yml run bump_version_major
+        run: docker compose -f docker-compose-ci.yml run bump_version_major
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Bump version (minor)
-        run: docker-compose -f docker-compose-ci.yml run bump_version_minor
+        run: docker compose -f docker-compose-ci.yml run bump_version_minor
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/bump-version-patch.yml
+++ b/.github/workflows/bump-version-patch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Bump version (patch)
-        run: docker-compose -f docker-compose-ci.yml run bump_version_patch
+        run: docker compose -f docker-compose-ci.yml run bump_version_patch
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Build schema from source
-        run: docker-compose -f docker-compose-ci.yml run update_from_remote_schema
+        run: docker compose -f docker-compose-ci.yml run update_from_remote_schema

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Build schema from source
-        run: docker-compose -f docker-compose-ci.yml run build_from_source
+        run: docker compose -f docker-compose-ci.yml run build_from_source
       - uses: actions/setup-node@v1
         with:
           node-version: 16

--- a/.github/workflows/rebuild-schema.yml
+++ b/.github/workflows/rebuild-schema.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Rebuild client from remote schema
-        run: docker-compose -f docker-compose-ci.yml run update_from_remote_schema
+        run: docker compose -f docker-compose-ci.yml run update_from_remote_schema
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@v3
         with:

--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ explicit there so not repeating it here.
 ## Build
 
 If you want to rebuild everything locally from the remote OpenAPI schema (as performed on CI):
-`docker-compose -f docker-compose-ci.yml run update_from_remote_schema`
+`docker compose -f docker-compose-ci.yml run update_from_remote_schema`
 
 If you want to make sure the build is succeeding but don't want to rebuild the client from the
 remote schema nor update with possible changes in the base client generator (as performed on CI):
-`docker-compose -f docker-compose-ci.yml run build_from_source`
+`docker compose -f docker-compose-ci.yml run build_from_source`
 
 For local builds, you can use a more lightweight version to rebuild the schema from the remote
 that doesn't make sure dependencies are installed and skips linting:
-`docker-compose -f docker-compose.yml run local_model_rebuild`
+`docker compose -f docker-compose.yml run local_model_rebuild`
 
 If you want to get hands on inside the container, you can get in and use the make commands as much
 as you want. To get a shell inside it, just do:
-`docker-compose -f docker-compose.yml run client`
+`docker compose -f docker-compose.yml run client`
 
 Once inside, you have all Makefile commands at your disposal. Feel free to explore the `Makefile` to
 see all available. Here are some examples:


### PR DESCRIPTION
Back in the days (TM) there used to be a separate docker-compose command.

Then the Docker people added a docker compose subcommand[1].

As far as I understand the docker-compose command is not present in the (most) recent Docker versions which made our build(s) fail[2]:

    Run docker-compose -f docker-compose-ci.yml run update_from_remote_schema
    /home/runner/work/_temp/ef6e0b15-9eec-483e-a40b-0c103f2759c1.sh: line 1: docker-compose: command not found
    Error: Process completed with exit code 127.

[1] https://github.com/docker-archive/compose-cli/issues/1404
[2] https://github.com/lune-climate/lune-ts/actions/runs/10354230801/job/28659010929