### PR TITLE
Upgrade base client generator (0.1.15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-        "@lune-climate/openapi-typescript-codegen": "^0.1.13",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.15",
         "@types/node": "^22.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -211,10 +211,11 @@
       }
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.14.tgz",
-      "integrity": "sha512-uJo7lhD1NQzNxZSL/3RJxB9JXkNG0VWC3dQBqt+r48YLGRN909gXdIZdQHe0wwOWVsVenR1PDfhiV4WSTMzbxQ==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.15.tgz",
+      "integrity": "sha512-vJrdI9pxtwsjthGaOW637pLD/Ch7J1qlxEP+FZ+aaDmCLAYQnd+cFXVj8VK3IfaEMYemWbkRKqGceeVF0si9Kw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "camelcase": "^6.3.0",
         "commander": "^9.0.0",
@@ -3816,7 +3817,7 @@
       "version": "git+ssh://git@github.com/lune-climate/eslint-config.git#e48d71330bd8e3b721c52feeace0ec80ce995744",
       "integrity": "sha512-TqP1ceFQO5tAH5kM2fSkqvcf3L3El8+WfGPFcKCWSk21Vu1dOwI2vh0kKyUepsD61lQegYutawxqNU7fwEzf4g==",
       "dev": true,
-      "from": "@lune-climate/eslint-config@github:lune-climate/eslint-config#e48d71330bd8e3b721c52feeace0ec80ce995744",
+      "from": "@lune-climate/eslint-config@git+https://github.com/lune-climate/eslint-config.git#master",
       "requires": {
         "eslint-config-prettier": "^9.0.0",
         "eslint-config-standard": "^17.1.0"
@@ -3840,9 +3841,9 @@
       }
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.14.tgz",
-      "integrity": "sha512-uJo7lhD1NQzNxZSL/3RJxB9JXkNG0VWC3dQBqt+r48YLGRN909gXdIZdQHe0wwOWVsVenR1PDfhiV4WSTMzbxQ==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.15.tgz",
+      "integrity": "sha512-vJrdI9pxtwsjthGaOW637pLD/Ch7J1qlxEP+FZ+aaDmCLAYQnd+cFXVj8VK3IfaEMYemWbkRKqGceeVF0si9Kw==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-    "@lune-climate/openapi-typescript-codegen": "^0.1.13",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.15",
     "typescript": "^5.1.6",
     "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.1",


### PR DESCRIPTION
The generator contains support for the `https-url` format which now exists in the API schema, making it a requirement for a successful build to occur.

The schema was not updated since this should happen automatically whenever docs change, only the generator was updated unblocking the build [^1].

[^1]: https://github.com/lune-climate/lune-ts/actions/runs/11670865015/job/32495994689