### PR TITLE
Upgrade openapi-typescript-codegen to v0.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-        "@lune-climate/openapi-typescript-codegen": "^0.1.15",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.16",
         "@types/node": "^22.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -211,11 +211,10 @@
       }
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.15.tgz",
-      "integrity": "sha512-vJrdI9pxtwsjthGaOW637pLD/Ch7J1qlxEP+FZ+aaDmCLAYQnd+cFXVj8VK3IfaEMYemWbkRKqGceeVF0si9Kw==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.16.tgz",
+      "integrity": "sha512-ssYRx2dIZCL+vGsH0yKA2KE16AO+rw+h3CgQ+QJ4+TfqYP/K3Qq5Q2s1pD7mEjGQ72Wv+SVY7X15EGqa+28jow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "camelcase": "^6.3.0",
         "commander": "^9.0.0",
@@ -3844,9 +3843,9 @@
       }
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.15.tgz",
-      "integrity": "sha512-vJrdI9pxtwsjthGaOW637pLD/Ch7J1qlxEP+FZ+aaDmCLAYQnd+cFXVj8VK3IfaEMYemWbkRKqGceeVF0si9Kw==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.16.tgz",
+      "integrity": "sha512-ssYRx2dIZCL+vGsH0yKA2KE16AO+rw+h3CgQ+QJ4+TfqYP/K3Qq5Q2s1pD7mEjGQ72Wv+SVY7X15EGqa+28jow==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-    "@lune-climate/openapi-typescript-codegen": "^0.1.15",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.16",
     "typescript": "^5.1.6",
     "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.1",


### PR DESCRIPTION
This change includes a fix to non-JSON responses.
Non-JSON response are now not modified.