### PR TITLE
Update openapi-typescript-generator to v0.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-        "@lune-climate/openapi-typescript-codegen": "^0.1.15",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.17",
         "@types/node": "^22.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -211,11 +211,10 @@
       }
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.15.tgz",
-      "integrity": "sha512-vJrdI9pxtwsjthGaOW637pLD/Ch7J1qlxEP+FZ+aaDmCLAYQnd+cFXVj8VK3IfaEMYemWbkRKqGceeVF0si9Kw==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.17.tgz",
+      "integrity": "sha512-33EfwZwY8YS8e+n4HEGem8xjdQujdYtDsRfXdBgFuCepalfbR/K399WbEHQNvr2GAfqzrBPCX+nfb2iidjmBSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "camelcase": "^6.3.0",
         "commander": "^9.0.0",
@@ -3844,9 +3843,9 @@
       }
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.15.tgz",
-      "integrity": "sha512-vJrdI9pxtwsjthGaOW637pLD/Ch7J1qlxEP+FZ+aaDmCLAYQnd+cFXVj8VK3IfaEMYemWbkRKqGceeVF0si9Kw==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.17.tgz",
+      "integrity": "sha512-33EfwZwY8YS8e+n4HEGem8xjdQujdYtDsRfXdBgFuCepalfbR/K399WbEHQNvr2GAfqzrBPCX+nfb2iidjmBSw==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-    "@lune-climate/openapi-typescript-codegen": "^0.1.15",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.17",
     "typescript": "^5.1.6",
     "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.1",


### PR DESCRIPTION
This change includes a fix to non-JSON responses.
Non-JSON response are now not modified.
