### PR TITLE
Adapt build process to new docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build:
 
 api-schema:
 	# Extract the latest calendar version also via the changelog in our docs. This is not perfect but should serve quite well for our purposes.
-	$(eval VERSION :=$(shell curl -L -s https://docs.lune.co/key-concepts/changelog | grep -oP '<code>\K\d{4}-\d{2}-\d{2}(?=</code>)' | sort | tail -n 1))
+	$(eval VERSION :=$(shell curl -L -s https://docs.lune.co/changelog.md | head -n 1 | tail -c 11))
 	npx @lune-climate/openapi-typescript-codegen -i https://docs.lune.co/openapi.yml --apiVersion '$(VERSION)' --output src --exportCore false --exportServices true --exportSchemas false
 
 move-client:

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,12 @@ fix-linting:
 build:
 	npm run build
 
+# FIXME: Due to the new docs not having the changelog page, our current VERSION is hardcoded.
+VERSION=2024-08-08
+
 api-schema:
 	# Extract the latest calendar version also via the changelog in our docs. This is not perfect but should serve quite well for our purposes.
-	$(eval VERSION :=$(shell curl -L -s https://docs.lune.co/key-concepts/changelog | grep -oP '<code>\K\d{4}-\d{2}-\d{2}(?=</code>)' | sort | tail -n 1))
+	# $(eval VERSION :=$(shell curl -L -s https://docs.lune.co/key-concepts/changelog | grep -oP '<code>\K\d{4}-\d{2}-\d{2}(?=</code>)' | sort | tail -n 1))
 	npx @lune-climate/openapi-typescript-codegen -i https://docs.lune.co/openapi.yml --apiVersion '$(VERSION)' --output src --exportCore false --exportServices true --exportSchemas false
 
 move-client:

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,9 @@ fix-linting:
 build:
 	npm run build
 
-# FIXME: Due to the new docs not having the changelog page, our current VERSION is hardcoded.
-VERSION=2024-08-08
-
 api-schema:
 	# Extract the latest calendar version also via the changelog in our docs. This is not perfect but should serve quite well for our purposes.
-	# $(eval VERSION :=$(shell curl -L -s https://docs.lune.co/key-concepts/changelog | grep -oP '<code>\K\d{4}-\d{2}-\d{2}(?=</code>)' | sort | tail -n 1))
+	$(eval VERSION :=$(shell curl -L -s https://docs.lune.co/key-concepts/changelog | grep -oP '<code>\K\d{4}-\d{2}-\d{2}(?=</code>)' | sort | tail -n 1))
 	npx @lune-climate/openapi-typescript-codegen -i https://docs.lune.co/openapi.yml --apiVersion '$(VERSION)' --output src --exportCore false --exportServices true --exportSchemas false
 
 move-client:


### PR DESCRIPTION
We extract the current version information from our public changelog page. Our docs are changing in a bit and our changelog page will not be presented and instead we'll have direct access to the changelog. This actually makes things a lot easier.