### PR TITLE
Pick up API schema changes daily

### DIFF
--- a/.github/workflows/rebuild-schema.yml
+++ b/.github/workflows/rebuild-schema.yml
@@ -1,9 +1,12 @@
 name: Rebuild client and open PR with changes
 
-# Perform workflow whenever we get a change in schema event
 on:
+  # Perform workflow whenever we get a change in schema event
   repository_dispatch:
     types: [rebuild_schema_change]
+  # Perform workflow daily to make sure we are never too stale
+  schedule:
+    - cron: "0 5 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
We could previously trigger the workflow only after changes to the schema were in place. However, this is no longer possible [^1].

To mitigate the problem, let's perform the workflow every day.

[^1]: https://github.com/lune-climate/lune-fe/pull/855