### PR TITLE
Pass `responseType` to Axios client

### DIFF
--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -208,6 +208,7 @@ export const request = async <T>(
         headers,
         params: formData,
         data: body,
+        ...(options.responseType ? { responseType: options.responseType } : {}),
     })
         .then((response: AxiosResponse<T>) => {
             return Ok(asSuccessResponse(headers, response))


### PR DESCRIPTION
`responseType`, introduced in https://github.com/lune-climate/openapi-typescript-codegen/pull/84
must be used by the Axios client for side effects to occur.
