### PR TITLE
Split SuccessResponse type

### DIFF
--- a/src/core/SuccessResponse.ts
+++ b/src/core/SuccessResponse.ts
@@ -18,7 +18,8 @@ type AsObject<T> = T extends object
         ? { notAnObject: T }
         : T
     : { notAnObject: T }
-export type SuccessResponse<T> = (AsObject<T> & { _meta: Meta<T> }) | T
+export type SuccessResponseWithMeta<T> = AsObject<T> & { _meta: Meta<T> }
+export type SuccessResponse<T> = SuccessResponseWithMeta<T> | T
 
 function isNotPureObject(value: unknown): boolean {
     return (


### PR DESCRIPTION
SuccessResponse has `_meta` or not.
Adding an intermediate type enables casting to one or the other in client code.
