### PR TITLE
Read response headers from Axios response object

### DIFF
--- a/src/core/SuccessResponse.ts
+++ b/src/core/SuccessResponse.ts
@@ -1,7 +1,5 @@
 import { AxiosError, AxiosResponse } from 'axios'
 
-import type { Headers } from './ClientConfig.js'
-
 export const Methods = ['get', 'delete', 'head', 'options', 'post', 'put', 'patch']
 export type Method = (typeof Methods)[number]
 
@@ -29,12 +27,9 @@ function isNotPureObject(value: unknown): boolean {
     )
 }
 
-export function asSuccessResponse<T>(
-    headers: Headers,
-    response: AxiosResponse<T>,
-): SuccessResponse<T> {
+export function asSuccessResponse<T>(response: AxiosResponse<T>): SuccessResponse<T> {
     const value: T = response.data
-    const contentType = headers['content-type']
+    const contentType = response.headers['content-type']
     if (contentType && contentType.includes('application/json')) {
         if (!('_meta' in response)) {
             throw new Error('_meta is expected')

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -211,7 +211,7 @@ export const request = async <T>(
         ...(options.responseType ? { responseType: options.responseType } : {}),
     })
         .then((response: AxiosResponse<T>) => {
-            return Ok(asSuccessResponse(headers, response))
+            return Ok(asSuccessResponse(response))
         })
         .catch((error: unknown) => {
             if (!isAxiosError(error)) {


### PR DESCRIPTION
`asSuccessResponse` needs to read the response's `Content-Type` header.
Prior to this change, it got the header from the `headers` variable.
The variable does not contain response headers but request headers.
