### PR TITLE
Halt build if fetching API version fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ fix-linting:
 build:
 	npm run build
 
+# Extract the latest calendar version also via the changelog in our docs. This is not perfect but should serve quite well for our purposes.
+VERSION := $(shell curl -L -f -s https://docs.lune.co/changelog.md | head -n 1 | tail -c 11)
+
 api-schema:
-	# Extract the latest calendar version also via the changelog in our docs. This is not perfect but should serve quite well for our purposes.
-	$(eval VERSION :=$(shell curl -L -s https://docs.lune.co/changelog.md | head -n 1 | tail -c 11))
+	@test -n "$(VERSION)" || { echo "Failed to fetch API version from the docs."; exit 1; }
 	npx @lune-climate/openapi-typescript-codegen -i https://docs.lune.co/openapi.yml --apiVersion '$(VERSION)' --output src --exportCore false --exportServices true --exportSchemas false
 
 move-client:


### PR DESCRIPTION
We fetch the current API version from the changelog that is publicly available in our docs. This step however can fail. Since the API version is a requirement to building the application, we should fail if the fetch has failed.

This was triggered due to an auto update PR which showcased an API version of `<html>` in a build due to a failure in fetching the changelog.

[^1]: https://github.com/lune-climate/lune-ts/pull/817