### PR TITLE
Upgrade to Node 22.13.1 in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.1
+FROM node:22.13.1
 
 # Why is this needed?
 #


### PR DESCRIPTION
Node 16 has been unmaintained for a long time[1]. Some of our dependencies stop being compatible with it, let's migrate to a newer engine to avoid problems.

22 because it's the current LTE line[1].

22.14.0 is out but not yet available on Docker Hub.

[1] https://nodejs.org/en/about/previous-releases