### PR TITLE
Upgrade to Node 18.20.6 in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.1
+FROM node:18.20.6
 
 # Why is this needed?
 #


### PR DESCRIPTION
Node 16 has been unmaintained for a long time[1]. Some of our dependencies stop being compatible with it, let's migrate to a newer engine to avoid problems.

[1] https://nodejs.org/en/about/previous-releases