### PR TITLE
Regenerate package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4357,7 +4357,7 @@
       "version": "git+ssh://git@github.com/lune-climate/eslint-config.git#e86dad4d0f848ba5e8e1e8056d9415253741e926",
       "integrity": "sha512-GXmc4POijh9d5TL8dzMWUs83/H9gMaXRQP+pSFSTea+9PJs8oYKXy3XMuXN8Ig1zBxzym0Ahvjpl6kGMSNnk4A==",
       "dev": true,
-      "from": "@lune-climate/eslint-config@github:lune-climate/eslint-config#e86dad4d0f848ba5e8e1e8056d9415253741e926",
+      "from": "@lune-climate/eslint-config@git+https://github.com/lune-climate/eslint-config.git#master",
       "requires": {
         "eslint-config-prettier": "^9.0.0"
       }
@@ -4510,8 +4510,7 @@
       "version": "8.38.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.38.0.tgz",
       "integrity": "sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@typescript-eslint/type-utils": {
       "version": "7.17.0",
@@ -4623,8 +4622,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
           "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -4736,8 +4734,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -5340,8 +5337,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
       "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.9",
@@ -5487,8 +5483,7 @@
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
       "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -6863,8 +6858,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-declaration-location": {
       "version": "1.0.7",


### PR DESCRIPTION
I think they adjusted the format slightly. I just ran

    npm install --legacy-peer-deps

with npm 10.9.3 (not the latest).