### PR TITLE
Support ts-results-es 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.4.0",
         "camelcase-keys": "<8.0.0",
         "snakecase-keys": "^9.0.2",
-        "ts-results-es": "^4.0.0 || ^5.0.1"
+        "ts-results-es": "^4.0.0 || ^5.0.1 || ^6.0.0"
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.4.0",
     "camelcase-keys": "<8.0.0",
     "snakecase-keys": "^9.0.2",
-    "ts-results-es": "^4.0.0 || ^5.0.1"
+    "ts-results-es": "^4.0.0 || ^5.0.1 || ^6.0.0"
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",


### PR DESCRIPTION
We've recently released 6.0.0, let's give the users of this package an option to use that.