### PR TITLE
Fix permissions issue in rebuild schema workflow

### DIFF
--- a/.github/workflows/rebuild-schema.yml
+++ b/.github/workflows/rebuild-schema.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Rebuild client from remote schema
         run: |
+          # --user preserves file ownership to match host user (prevents permission issues)
+          # -e sets npm cache directory to avoid permission conflicts in container
           docker compose -f docker-compose-ci.yml run \
             --user $(id -u):$(id -g) \
             -e NPM_CONFIG_CACHE=/tmp/.npm-cache \


### PR DESCRIPTION
There is a file ownership and permission mismatch between docker and github actions. 
For the past 5 days the `rebuild_schema_change` workflow has been broken.

We get errors like 
```
warning: unable to unlink 'src/models/AircraftConfiguration.ts': Permission denied
 error: unable to unlink old 'src/models/FlightNumberMethod.ts': Permission denied
Switched to branch 'master'
M src/models/FlightNumberMethod.ts
Your branch is up to date with 'origin/master'.
/usr/bin/git reset --hard origin/master
error: unable to unlink old 'src/models/FlightNumberMethod.ts': Permission denied
fatal: Could not reset index file to revision 'origin/master'.
```


This is an LLM suggested fix, which says

```
By using $(id -u):$(id -g), you're telling Docker:
"Run this container as the same user that's currently running this shell command"
```

We also need `-e NPM_CONFIG_CACHE=/tmp/.npm-cache` or similar, because if we simply switch the uid/gid to one that the Docker image doesn't know about it doesn't have a home directory and NPM tries to write to /.npm and it fails
