### PR TITLE
[LUN-5221] Upgrade axios to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.8.4",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.4.0",
+        "axios": "^1.15.0",
         "camelcase-keys": "<8.0.0",
         "snakecase-keys": "<9.0.0",
         "ts-results-es": "^4.0.0 || ^5.0.1 || ^6.0.0 || ^7.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fix-format": "eslint --fix \"src/**/*.ts\" && prettier --write \"src/**/*.ts\""
   },
   "dependencies": {
-    "axios": "^1.4.0",
+    "axios": "^1.15.0",
     "camelcase-keys": "<8.0.0",
     "snakecase-keys": "<9.0.0",
     "ts-results-es": "^4.0.0 || ^5.0.1 || ^6.0.0 || ^7.0.0"


### PR DESCRIPTION
This version fixes multiple security vulnerabilities compared to the version we've been using.

The latest fixes introduced in 1.15.0[1]:

    Header Injection (CRLF): Rejects any header value containing \r or \n
    characters to block CRLF injection chains that could be used to
    exfiltrate cloud metadata (IMDS). Behavior change: headers with CR/LF
    now throw "Invalid character in header content". (#10660)

    SSRF via no_proxy Bypass: Introduces a shouldBypassProxy helper that
    normalises hostnames (strips trailing dots, handles bracketed IPv6)
    before evaluating no_proxy/NO_PROXY rules, closing a gap that could
    cause loopback or internal hosts to be inadvertently proxied. (#10661)

I think the users of this library still could use the latest axios version even withou thtis change but let's make it clear that we want it.

[1] https://github.com/axios/axios/blob/19e9b4162d4a2845c6e99e425b81a6071171a6df/CHANGELOG.md#v1150--april-7-2026

Part-of: https://linear.app/gryn/issue/LUN-5221/ensure-we-are-running-axios-115