### PR TITLE
Require ts-results-es 6.0+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.15.0",
         "camelcase-keys": "<8.0.0",
         "snakecase-keys": "<9.0.0",
-        "ts-results-es": "^4.0.0 || ^5.0.1 || ^6.0.0 || ^7.0.0"
+        "ts-results-es": "^6.0.0 || ^7.0.0"
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.15.0",
     "camelcase-keys": "<8.0.0",
     "snakecase-keys": "<9.0.0",
-    "ts-results-es": "^4.0.0 || ^5.0.1 || ^6.0.0 || ^7.0.0"
+    "ts-results-es": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",


### PR DESCRIPTION
This change prepares us for updating the code generator to [1] which requires ts-results-e 6.0+.

[1] https://github.com/lune-climate/openapi-typescript-codegen/pull/86