### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/bump-version-major.yml
+++ b/.github/workflows/bump-version-major.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Bump version (major)
         run: docker compose -f docker-compose-ci.yml run bump_version_major
       - name: Create PR with changes
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           token: ${{ secrets.CLIENT_REBUILD_TOKEN_GITHUB }}
           commit-message: Bump version (major)

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Bump version (minor)
         run: docker compose -f docker-compose-ci.yml run bump_version_minor
       - name: Create PR with changes
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           token: ${{ secrets.CLIENT_REBUILD_TOKEN_GITHUB }}
           commit-message: Bump version (minor)

--- a/.github/workflows/bump-version-patch.yml
+++ b/.github/workflows/bump-version-patch.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Bump version (patch)
         run: docker compose -f docker-compose-ci.yml run bump_version_patch
       - name: Create PR with changes
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           token: ${{ secrets.CLIENT_REBUILD_TOKEN_GITHUB }}
           commit-message: Bump version (patch)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Build schema from source
         run: docker compose -f docker-compose-ci.yml run update_from_remote_schema

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Build schema from source
         run: docker compose -f docker-compose-ci.yml run build_from_source
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/rebuild-schema.yml
+++ b/.github/workflows/rebuild-schema.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Rebuild client from remote schema
         run: |
           # --user preserves file ownership to match host user (prevents permission issues)
@@ -25,7 +25,7 @@ jobs:
             update_from_remote_schema
         
       - name: Create PR with changes
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           token: ${{ secrets.CLIENT_REBUILD_TOKEN_GITHUB }}
           commit-message: Client auto update


### PR DESCRIPTION
Mutable action tags can change without repository review. Pin all actions so we always know what we run.

Dependabot will be able to update them, I'll configure this separately.