### PR TITLE
Restrict GHA workflow permissions

### DIFF
--- a/.github/workflows/bump-version-major.yml
+++ b/.github/workflows/bump-version-major.yml
@@ -4,10 +4,15 @@ name: Create PR with bump major version
 on:
   - workflow_dispatch
 
+permissions: {}
+
 jobs:
   build:
     name: Bump version (major) and create PR.
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -4,10 +4,15 @@ name: Create PR with bump minor version
 on:
   - workflow_dispatch
 
+permissions: {}
+
 jobs:
   build:
     name: Bump version (minor) and create PR.
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/bump-version-patch.yml
+++ b/.github/workflows/bump-version-patch.yml
@@ -4,10 +4,15 @@ name: Create PR with bump patch version
 on:
   - workflow_dispatch
 
+permissions: {}
+
 jobs:
   build:
     name: Bump version (patch) and create PR.
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: Build client on CI
 
 on: [push]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/rebuild-schema.yml
+++ b/.github/workflows/rebuild-schema.yml
@@ -8,9 +8,14 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout the code


### PR DESCRIPTION
Repository defaults can grant more GITHUB_TOKEN access than these workflows require. Disable ambient permissions and grant each job only the repository read or pull request write access needed for its task.

This doesn't touch the publishing workflow which I will fix separately.