### PR TITLE
Disable checkout credential persistence

### DIFF
--- a/.github/workflows/bump-version-major.yml
+++ b/.github/workflows/bump-version-major.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        with:
+          persist-credentials: false
       - name: Bump version (major)
         run: docker compose -f docker-compose-ci.yml run bump_version_major
       - name: Create PR with changes

--- a/.github/workflows/bump-version-minor.yml
+++ b/.github/workflows/bump-version-minor.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        with:
+          persist-credentials: false
       - name: Bump version (minor)
         run: docker compose -f docker-compose-ci.yml run bump_version_minor
       - name: Create PR with changes

--- a/.github/workflows/bump-version-patch.yml
+++ b/.github/workflows/bump-version-patch.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        with:
+          persist-credentials: false
       - name: Bump version (patch)
         run: docker compose -f docker-compose-ci.yml run bump_version_patch
       - name: Create PR with changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,7 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        with:
+          persist-credentials: false
       - name: Build schema from source
         run: docker compose -f docker-compose-ci.yml run update_from_remote_schema

--- a/.github/workflows/rebuild-schema.yml
+++ b/.github/workflows/rebuild-schema.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        with:
+          persist-credentials: false
       - name: Rebuild client from remote schema
         run: |
           # --user preserves file ownership to match host user (prevents permission issues)


### PR DESCRIPTION
The checkout action stores credentials in the workspace by default, allowing later steps to reuse them. Disable thaa where possible.

I'm not changing the publishing workflow, I will be fixing it separately.