### PR TITLE
Set Dependabot update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Without this we could update to a freshly-released infected versions of some dependencies. This is a good practice to only allow dependencies that have been around for a while.