### PR TITLE
Enable Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: weekly
   cooldown:
     default-days: 7
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
We pin the versions so they won't update transparently behind the scenes. We could use some automation to help us stay up to date.