### PR TITLE
Re-do publishing workflow with npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,21 +2,65 @@ name: Publish new version
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*'
+
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout the code
-        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build schema from source
         run: docker compose -f docker-compose-ci.yml run build_from_source
-      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+      - name: Create release artifact directory
+        run: mkdir -p npm-package
+      - name: Pack release artifact
+        run: npm pack ./dist --ignore-scripts --pack-destination npm-package
+      - name: Verify release artifact
+        shell: bash
+        run: |
+          mapfile -t tarballs < <(find npm-package -maxdepth 1 -type f -name '*.tgz' -print)
+          test "${#tarballs[@]}" -eq 1
+      - name: Upload release artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
-      - run: make publish-ignore-same-version-error
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          name: npm-package
+          path: npm-package
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: npm-publish
+      cancel-in-progress: false
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/@lune-climate/lune
+    permissions:
+      id-token: write
+    steps:
+      - name: Download release artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: npm-package
+          path: dist
+      - name: Set up Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: '26.5.0'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Stage release artifact
+        shell: bash
+        run: |
+          mapfile -t tarballs < <(find dist -maxdepth 1 -type f -name '*.tgz' -print)
+          test "${#tarballs[@]}" -eq 1
+          npm stage publish "./${tarballs[0]}"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SHELL := /bin/bash # Required for the publish ignoring same version error
-
 .PHONY: build-image
 build-image:
 	docker compose build
@@ -54,15 +52,3 @@ minor-version:
 major-version:
 	npm --no-git-tag-version version major
 	npm ci --legacy-peer-deps
-
-publish:
-	cd dist && npm publish --access public
-
-# Publishing over the same version error is ignored and that line of the error log is shown. On any other
-# error or success behaviour is the same.
-ERROR_FILE = ./publish_error.log
-publish-ignore-same-version-error:
-	make publish 2>$(ERROR_FILE) ; true
-	if [[ -f "$(ERROR_FILE)" ]]; then \
-		grep "You cannot publish over the previously published versions:" $(ERROR_FILE) || cat $(ERROR_FILE); \
-	fi;

--- a/README.md
+++ b/README.md
@@ -111,11 +111,16 @@ An API change was released to Production. You want to start using it via the lun
    
    Wait for job to finish.
 5. ts-lune repo: 4. should create a PR that bumps the ts-client to a new version. Approve and merge this.
-6. npm registry: Go to and wait until you can see that the new version was published https://www.npmjs.com/package/@lune-climate/lune (this should have happened automatically after merging new version number to MASTER as seen in step 5. but seems slow - give it a min)
-7. Bump the version of ts-client in your local repo to match the newly published npm version, run yarn/npm to install it and start using it
-
-Diagram you don't actually need to look at:
-<img width="1493" alt="image" src="https://user-images.githubusercontent.com/3956723/182634194-0d55a2e0-3832-4e60-8029-38194f4f5ee5.png">
+6. ts-lune repo: Create and push a release tag matching the package version, for example `v3.9.1`,
+   on the commit merged in step 5. This triggers the **Publish new version** workflow.
+7. GitHub Actions: Approve the `npm-publish` environment deployment in the **Publish new version**
+   workflow. The workflow builds the package without publishing credentials and stages the
+   resulting tarball on npm using trusted publishing.
+8. npm registry: In npmjs.com, open the **Staged Packages** tab for the signed-in maintainer
+   account, review the staged package, then approve it with 2FA. Wait until the new version
+   appears on https://www.npmjs.com/package/@lune-climate/lune.
+9. Bump the version of ts-client in your local repo to match the newly published npm version,
+   run yarn/npm to install it and start using it.
 
 ## Future work
 


### PR DESCRIPTION
Replaces the long-lived release token with a job-scoped OIDC identity. NPM doesn't support long-lived tokens anymore.

This change technically changes versions of some actions but treat this patch as a complete replacement. These action versions are known to work in this setup.