### PR TITLE
Upgrade openapi-typescript-codegen from 0.1.18 to 0.1.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-        "@lune-climate/openapi-typescript-codegen": "^0.1.18",
+        "@lune-climate/openapi-typescript-codegen": "^0.1.22",
         "@types/node": "^26.0.1",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^8.21.0",
@@ -170,10 +170,11 @@
       }
     },
     "node_modules/@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.18.tgz",
-      "integrity": "sha512-IFF0FgEoc3I2UBcEK2wGq5y8GG98PsMiQOFVN/xNYZ7xWj54ylzFGRZWXzfjsv3+6fFjaivhvtnxPRLRSe52YQ==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.22.tgz",
+      "integrity": "sha512-bR6NZCt1rbJLKWjmOyFJjfASTVqu//EMCfvY4+bxMLAecgI+xzXrpHix6zLf8QPx9dw4wOoZzLB4Avfnz6bstw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "camelcase": "^6.3.0",
         "commander": "^9.0.0",
@@ -4512,9 +4513,9 @@
       }
     },
     "@lune-climate/openapi-typescript-codegen": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.18.tgz",
-      "integrity": "sha512-IFF0FgEoc3I2UBcEK2wGq5y8GG98PsMiQOFVN/xNYZ7xWj54ylzFGRZWXzfjsv3+6fFjaivhvtnxPRLRSe52YQ==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@lune-climate/openapi-typescript-codegen/-/openapi-typescript-codegen-0.1.22.tgz",
+      "integrity": "sha512-bR6NZCt1rbJLKWjmOyFJjfASTVqu//EMCfvY4+bxMLAecgI+xzXrpHix6zLf8QPx9dw4wOoZzLB4Avfnz6bstw==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -4659,8 +4660,7 @@
       "version": "8.65.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
       "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@typescript-eslint/type-utils": {
       "version": "7.17.0",
@@ -4777,8 +4777,7 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
           "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -4890,8 +4889,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.14.0",
@@ -5498,8 +5496,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
       "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.4.0",
@@ -5656,8 +5653,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-14.0.0.tgz",
       "integrity": "sha512-NUJO0+XFCkk+o5EsAJruTgnfMEpeWrPWeJS15UVF60GgXmqz1BJ9/3hzlvG7lkL8Bubzos5cCLptThbFfPnSMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -7089,8 +7085,7 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "picomatch": {
           "version": "4.0.5",
@@ -7113,8 +7108,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-declaration-location": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@lune-climate/eslint-config": "git+https://github.com/lune-climate/eslint-config.git#master",
-    "@lune-climate/openapi-typescript-codegen": "^0.1.18",
+    "@lune-climate/openapi-typescript-codegen": "^0.1.22",
     "typescript": "^5.1.6",
     "@types/node": "^26.0.1",
     "@typescript-eslint/eslint-plugin": "^7.0.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,7 +69,7 @@ export class LuneClient {
             response: AxiosResponse,
         ): AxiosResponse | ExtendedAxiosResponse => {
             const contentType = response.headers['content-type']
-            if (!contentType || !contentType.includes('application/json')) {
+            if (typeof contentType !== 'string' || !contentType.includes('application/json')) {
                 return response
             }
             return {

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import snakeCaseKeys from 'snakecase-keys'
-import { Err, Ok, Result } from 'ts-results-es'
+import { AsyncResult, Err, Ok } from 'ts-results-es'
 
 import { ApiError, constructApiError } from './ApiError.js'
 import type { ApiRequestOptions } from './ApiRequestOptions.js'
@@ -185,14 +185,14 @@ const getRequestBody = (options: ApiRequestOptions): any => {
     }
 }
 
-export const request = async <T>(
+export const request = <T>(
     client: AxiosInstance,
     config: ClientConfig,
     luneOptions: {
         accountId?: string
     },
     options: ApiRequestOptions,
-): Promise<Result<SuccessResponse<T>, ApiError>> => {
+): AsyncResult<SuccessResponse<T>, ApiError> => {
     const url = getUrl(config, options)
     const formData = getFormData(options)
     const body = getRequestBody(options)
@@ -202,21 +202,23 @@ export const request = async <T>(
         headers['Lune-Account'] = luneOptions.accountId
     }
 
-    return client({
-        baseURL: url,
-        method: options.method,
-        headers,
-        params: formData,
-        data: body,
-        ...(options.responseType ? { responseType: options.responseType } : {}),
-    })
-        .then((response: AxiosResponse<T>) => {
-            return Ok(asSuccessResponse(response))
+    return new AsyncResult(
+        client({
+            baseURL: url,
+            method: options.method,
+            headers,
+            params: formData,
+            data: body,
+            ...(options.responseType ? { responseType: options.responseType } : {}),
         })
-        .catch((error: unknown) => {
-            if (!isAxiosError(error)) {
-                throw error
-            }
-            return Err(constructApiError(error, options))
-        })
+            .then((response: AxiosResponse<T>) => {
+                return Ok(asSuccessResponse(response))
+            })
+            .catch((error: unknown) => {
+                if (!isAxiosError(error)) {
+                    throw error
+                }
+                return Err(constructApiError(error, options))
+            }),
+    )
 }

--- a/src/services/AccountsService.ts
+++ b/src/services/AccountsService.ts
@@ -22,7 +22,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class AccountsService {
     protected abstract client: AxiosInstance
@@ -38,7 +38,7 @@ export abstract class AccountsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<SuccessResponse<Account>, ApiError>> {
+    }): AsyncResult<SuccessResponse<Account>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts/me',
@@ -90,7 +90,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<AccountPair>, ApiError>> {
+    ): AsyncResult<SuccessResponse<AccountPair>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts',
@@ -148,7 +148,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedAccounts>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedAccounts>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts',
@@ -207,7 +207,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Account>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Account>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/accounts/{id}',
@@ -277,7 +277,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Account>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Account>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/accounts/{id}',
@@ -326,7 +326,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<UploadLogoResponse>, ApiError>> {
+    ): AsyncResult<SuccessResponse<UploadLogoResponse>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts/{id}/logo',
@@ -366,7 +366,7 @@ export abstract class AccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<UploadLogoResponse>, ApiError>> {
+    ): AsyncResult<SuccessResponse<UploadLogoResponse>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/accounts/{id}/logo',

--- a/src/services/AnalyticsService.ts
+++ b/src/services/AnalyticsService.ts
@@ -20,7 +20,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class AnalyticsService {
     protected abstract client: AxiosInstance
@@ -51,7 +51,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<CumulativeBundleAnalytics>, ApiError>> {
+    ): AsyncResult<SuccessResponse<CumulativeBundleAnalytics>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/cumulative-per-bundle',
@@ -95,7 +95,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<AnalyticsMetrics>, ApiError>> {
+    ): AsyncResult<SuccessResponse<AnalyticsMetrics>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/metrics',
@@ -139,7 +139,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<AggregatedAnalyticsByProperty>, ApiError>> {
+    ): AsyncResult<SuccessResponse<AggregatedAnalyticsByProperty>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/aggregated-by-property',
@@ -193,7 +193,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<EmissionCalculationMetrics>, ApiError>> {
+    ): AsyncResult<SuccessResponse<EmissionCalculationMetrics>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/emission-calculations',
@@ -244,7 +244,7 @@ export abstract class AnalyticsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<BusinessEmissionsAnalytics>, ApiError>> {
+    ): AsyncResult<SuccessResponse<BusinessEmissionsAnalytics>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/analytics/business',

--- a/src/services/BundlePortfoliosService.ts
+++ b/src/services/BundlePortfoliosService.ts
@@ -16,7 +16,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class BundlePortfoliosService {
     protected abstract client: AxiosInstance
@@ -32,7 +32,7 @@ export abstract class BundlePortfoliosService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<SuccessResponse<Array<BundlePortfolio>>, ApiError>> {
+    }): AsyncResult<SuccessResponse<Array<BundlePortfolio>>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundle-portfolios',
@@ -62,7 +62,7 @@ export abstract class BundlePortfoliosService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<BundlePortfolio>, ApiError>> {
+    ): AsyncResult<SuccessResponse<BundlePortfolio>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/bundle-portfolios',

--- a/src/services/BundleSelectionsService.ts
+++ b/src/services/BundleSelectionsService.ts
@@ -17,7 +17,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class BundleSelectionsService {
     protected abstract client: AxiosInstance
@@ -33,7 +33,7 @@ export abstract class BundleSelectionsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<SuccessResponse<BundleSelection>, ApiError>> {
+    }): AsyncResult<SuccessResponse<BundleSelection>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundle-selections',
@@ -63,7 +63,7 @@ export abstract class BundleSelectionsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<BundleSelection>, ApiError>> {
+    ): AsyncResult<SuccessResponse<BundleSelection>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/bundle-selections',

--- a/src/services/BundlesService.ts
+++ b/src/services/BundlesService.ts
@@ -17,7 +17,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class BundlesService {
     protected abstract client: AxiosInstance
@@ -54,7 +54,7 @@ export abstract class BundlesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedBundles>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedBundles>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundles',
@@ -88,7 +88,7 @@ export abstract class BundlesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Bundle>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Bundle>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/bundles/{id}',

--- a/src/services/ClientAccountsService.ts
+++ b/src/services/ClientAccountsService.ts
@@ -22,7 +22,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class ClientAccountsService {
     protected abstract client: AxiosInstance
@@ -38,7 +38,7 @@ export abstract class ClientAccountsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
+    }): AsyncResult<SuccessResponse<ClientAccount>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts/client/me',
@@ -86,7 +86,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ClientAccount>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts/client',
@@ -148,7 +148,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedClientAccounts>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedClientAccounts>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/accounts/client',
@@ -188,7 +188,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ClientAccount>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/accounts/client/{id}',
@@ -251,7 +251,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ClientAccount>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ClientAccount>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/accounts/client/{id}',
@@ -300,7 +300,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<UploadLogoResponse>, ApiError>> {
+    ): AsyncResult<SuccessResponse<UploadLogoResponse>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/accounts/client/{id}/logo',
@@ -340,7 +340,7 @@ export abstract class ClientAccountsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<UploadLogoResponse>, ApiError>> {
+    ): AsyncResult<SuccessResponse<UploadLogoResponse>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/accounts/client/{id}/logo',

--- a/src/services/EmissionEstimatesService.ts
+++ b/src/services/EmissionEstimatesService.ts
@@ -65,7 +65,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class EmissionEstimatesService {
     protected abstract client: AxiosInstance
@@ -104,7 +104,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ElectricityEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ElectricityEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/electricity',
@@ -147,7 +147,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ElectricityEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ElectricityEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/electricity/{id}',
@@ -202,7 +202,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ElectricityEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ElectricityEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/electricity/{id}',
@@ -269,7 +269,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<FlightEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<FlightEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/flight',
@@ -346,7 +346,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PassengerTransportationEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PassengerTransportationEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/passenger-transportation',
@@ -392,7 +392,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PassengerTransportationEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PassengerTransportationEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/passenger-transportation/{id}',
@@ -435,7 +435,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PassengerTransportationEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PassengerTransportationEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/passenger-transportation/{id}/annotations',
@@ -515,7 +515,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedAnyShippingEmissionEstimates>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedAnyShippingEmissionEstimates>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/shipping/all',
@@ -580,7 +580,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<SingleShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/shipping',
@@ -625,7 +625,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<SingleShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/shipping/{id}',
@@ -690,7 +690,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<SingleShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/shipping/{id}',
@@ -759,7 +759,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<SingleShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<SingleShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/shipping/{id}/annotations',
@@ -836,7 +836,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/shipping/multi-leg',
@@ -894,7 +894,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/shipping/multi-leg/{id}',
@@ -970,7 +970,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/shipping/multi-leg/{id}',
@@ -1052,7 +1052,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<MultiLegShippingEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/shipping/multi-leg/{id}/annotations',
@@ -1124,7 +1124,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<CreateMultiLegShippingEstimateByFuelResponse>, ApiError>> {
+    ): AsyncResult<SuccessResponse<CreateMultiLegShippingEstimateByFuelResponse>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/shipping/multi-leg/by-fuel',
@@ -1172,7 +1172,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<CreateMultiLegShippingEstimateByFuelResponse>, ApiError>> {
+    ): AsyncResult<SuccessResponse<CreateMultiLegShippingEstimateByFuelResponse>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/shipping/multi-leg/by-fuel/{id}',
@@ -1220,7 +1220,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionDocumentEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionDocumentEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/transaction-documents',
@@ -1278,7 +1278,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<void>, ApiError>> {
+    ): AsyncResult<SuccessResponse<void>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/transaction-documents/async',
@@ -1313,7 +1313,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionDocumentEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionDocumentEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/transaction-documents/{id}',
@@ -1350,7 +1350,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/transactions',
@@ -1391,7 +1391,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<BatchTransactionEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<BatchTransactionEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/transactions/batch',
@@ -1429,7 +1429,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/transactions/by-idempotency-key/{idempotency_key}',
@@ -1474,7 +1474,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/transactions/{id}/annotations',
@@ -1527,7 +1527,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionDocumentEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionDocumentEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/estimates/transaction-documents/{id}/annotations',
@@ -1568,7 +1568,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/transactions/{id}',
@@ -1609,7 +1609,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<TransactionEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<TransactionEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/transactions/{id}',
@@ -1683,13 +1683,11 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<
-        Result<
-            SuccessResponse<{
-                estimates?: Array<TransactionEmissionEstimate>
-            }>,
-            ApiError
-        >
+    ): AsyncResult<
+        SuccessResponse<{
+            estimates?: Array<TransactionEmissionEstimate>
+        }>,
+        ApiError
     > {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
@@ -1841,7 +1839,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<CompanyEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<CompanyEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/company',
@@ -1905,7 +1903,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<CompanyEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<CompanyEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/company/{id}',
@@ -2038,7 +2036,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<CompanyEmissionEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<CompanyEmissionEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/estimates/company/{id}',
@@ -2123,7 +2121,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<EmissionFactorEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<EmissionFactorEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/estimates/emission-factor',
@@ -2164,7 +2162,7 @@ export abstract class EmissionEstimatesService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<EmissionFactorEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<EmissionFactorEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/estimates/emission-factor/{id}',

--- a/src/services/EmissionFactorsService.ts
+++ b/src/services/EmissionFactorsService.ts
@@ -19,7 +19,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class EmissionFactorsService {
     protected abstract client: AxiosInstance
@@ -98,7 +98,7 @@ export abstract class EmissionFactorsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedEmissionFactors>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedEmissionFactors>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/emission-factors',
@@ -135,7 +135,7 @@ export abstract class EmissionFactorsService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<SuccessResponse<EmissionFactorRegions>, ApiError>> {
+    }): AsyncResult<SuccessResponse<EmissionFactorRegions>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/emission-factors/regions',

--- a/src/services/OrdersService.ts
+++ b/src/services/OrdersService.ts
@@ -29,7 +29,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class OrdersService {
     protected abstract client: AxiosInstance
@@ -52,7 +52,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<OrderByQuantity>, ApiError>> {
+    ): AsyncResult<SuccessResponse<OrderByQuantity>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass',
@@ -116,7 +116,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<OrderByValue>, ApiError>> {
+    ): AsyncResult<SuccessResponse<OrderByValue>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-value',
@@ -178,7 +178,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<OrderByEstimate>, ApiError>> {
+    ): AsyncResult<SuccessResponse<OrderByEstimate>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-estimate',
@@ -239,7 +239,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedOrders>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedOrders>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders',
@@ -273,7 +273,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Order>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Order>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders/{id}',
@@ -304,7 +304,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Blob>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Blob>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders/{id}/certificate',
@@ -339,7 +339,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Order>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Order>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/orders/by-idempotency-key/{idempotency_key}',
@@ -377,7 +377,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<OrderQuoteByQuantity>, ApiError>> {
+    ): AsyncResult<SuccessResponse<OrderQuoteByQuantity>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-mass/quote',
@@ -425,7 +425,7 @@ export abstract class OrdersService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<OrderQuoteByValue>, ApiError>> {
+    ): AsyncResult<SuccessResponse<OrderQuoteByValue>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/orders/by-value/quote',

--- a/src/services/PaymentsService.ts
+++ b/src/services/PaymentsService.ts
@@ -16,7 +16,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class PaymentsService {
     protected abstract client: AxiosInstance
@@ -40,7 +40,7 @@ export abstract class PaymentsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Payment>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Payment>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/payments/by-temporary-id/{temporary_id}',

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -18,7 +18,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class ProjectsService {
     protected abstract client: AxiosInstance
@@ -55,7 +55,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedProjects>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedProjects>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects',
@@ -89,7 +89,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Project>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Project>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects/{id}',
@@ -120,7 +120,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ProjectPerimeter>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ProjectPerimeter>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects/{id}/perimeter',
@@ -151,7 +151,7 @@ export abstract class ProjectsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Project>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Project>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/projects/by-slug/{slug}',

--- a/src/services/ShipmentsService.ts
+++ b/src/services/ShipmentsService.ts
@@ -20,7 +20,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class ShipmentsService {
     protected abstract client: AxiosInstance
@@ -114,7 +114,7 @@ export abstract class ShipmentsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PaginatedShipments>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PaginatedShipments>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/shipments',
@@ -217,16 +217,14 @@ export abstract class ShipmentsService {
              */
             accountId?: string
         },
-    ): Promise<
-        Result<
-            SuccessResponse<{
-                /**
-                 * Batch identifier.
-                 */
-                id: string
-            }>,
-            ApiError
-        >
+    ): AsyncResult<
+        SuccessResponse<{
+            /**
+             * Batch identifier.
+             */
+            id: string
+        }>,
+        ApiError
     > {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
@@ -271,7 +269,7 @@ export abstract class ShipmentsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<ShipmentBatch>, ApiError>> {
+    ): AsyncResult<SuccessResponse<ShipmentBatch>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/shipments/batches/{id}',
@@ -306,7 +304,7 @@ export abstract class ShipmentsService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Shipment>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Shipment>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/shipments/{id}',

--- a/src/services/SustainabilityPageService.ts
+++ b/src/services/SustainabilityPageService.ts
@@ -25,7 +25,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class SustainabilityPageService {
     protected abstract client: AxiosInstance
@@ -53,7 +53,7 @@ export abstract class SustainabilityPageService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<SustainabilityPage>, ApiError>> {
+    ): AsyncResult<SuccessResponse<SustainabilityPage>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/sustainability-pages',
@@ -102,7 +102,7 @@ export abstract class SustainabilityPageService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<SustainabilityPage>, ApiError>> {
+    ): AsyncResult<SuccessResponse<SustainabilityPage>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/sustainability-pages',
@@ -140,7 +140,7 @@ export abstract class SustainabilityPageService {
          * Account Id to be used to perform the API call
          */
         accountId?: string
-    }): Promise<Result<SuccessResponse<SustainabilityPage>, ApiError>> {
+    }): AsyncResult<SuccessResponse<SustainabilityPage>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/sustainability-pages/current-account',
@@ -173,7 +173,7 @@ export abstract class SustainabilityPageService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PublicSustainabilityPage>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PublicSustainabilityPage>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/sustainability-pages/public/{type}/{slug}',
@@ -211,7 +211,7 @@ export abstract class SustainabilityPageService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<PublicSustainabilityPage>, ApiError>> {
+    ): AsyncResult<SuccessResponse<PublicSustainabilityPage>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/sustainability-pages/public/{organisation_id}/{type}/{handle}',

--- a/src/services/WebhookRequestService.ts
+++ b/src/services/WebhookRequestService.ts
@@ -16,7 +16,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class WebhookRequestService {
     protected abstract client: AxiosInstance
@@ -43,7 +43,7 @@ export abstract class WebhookRequestService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<any>, ApiError>> {
+    ): AsyncResult<SuccessResponse<any>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/WebhookRequest',

--- a/src/services/WebhooksService.ts
+++ b/src/services/WebhooksService.ts
@@ -18,7 +18,7 @@ import { request as __request } from '../core/request.js'
 import { SuccessResponse } from '../core/SuccessResponse.js'
 import { ApiError } from '../core/ApiError.js'
 import { AxiosInstance } from 'axios'
-import { Result } from 'ts-results-es'
+import { AsyncResult } from 'ts-results-es'
 
 export abstract class WebhooksService {
     protected abstract client: AxiosInstance
@@ -44,7 +44,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Array<Webhook>>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Array<Webhook>>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/webhooks',
@@ -84,7 +84,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<WebhookFullSecret>, ApiError>> {
+    ): AsyncResult<SuccessResponse<WebhookFullSecret>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/webhooks',
@@ -120,7 +120,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Webhook>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Webhook>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/webhooks/{id}',
@@ -170,7 +170,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<Webhook>, ApiError>> {
+    ): AsyncResult<SuccessResponse<Webhook>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/webhooks/{id}',
@@ -210,7 +210,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<void>, ApiError>> {
+    ): AsyncResult<SuccessResponse<void>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/webhooks/{id}',
@@ -242,7 +242,7 @@ export abstract class WebhooksService {
              */
             accountId?: string
         },
-    ): Promise<Result<SuccessResponse<WebhookFullSecret>, ApiError>> {
+    ): AsyncResult<SuccessResponse<WebhookFullSecret>, ApiError> {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/webhooks/{id}/rotate-secret',


### PR DESCRIPTION
Just keeping it up to date and importing two features:

* Returning AsyncResult instead from Promise<Result> from service methods for greater client code flexibility (supports awaiting just like before and more).
* Axios 1.18.0+ compatibility.

All code has been regenerated with the new version or adjusted where needed.